### PR TITLE
ci: skip homebrew for prereleases and derive prerelease from tag

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   publish:
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,11 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Tag version: $VERSION"
+          if [[ "$VERSION" =~ (rc|alpha|beta|pre) ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -150,6 +155,6 @@ jobs:
             release/*.tar.gz
             release/SHA256SUMS
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.tag_version.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Skip the Homebrew Tap publish job when `github.event.release.prerelease` is true, so rc/alpha/beta tags don't try to update the formula.
- Derive `prerelease` in the Release workflow from the tag suffix (`rc`/`alpha`/`beta`/`pre`) instead of hardcoding `false`, so softprops/action-gh-release can finalize prerelease tags cleanly.

## Context
On tag `v0.1.43.rc1` the Homebrew Tap workflow failed with `no assets to download` ([run 22259950674](https://github.com/guibeira/wakezilla/actions/runs/22259950674/job/64396585107)) because it triggered before any assets were attached to the release. The paired Release workflow also failed at `Finalizing release… Too many retries` ([run 22259950650](https://github.com/guibeira/wakezilla/actions/runs/22259950650)) because the tag is a prerelease but the workflow tried to mark the release as stable.

## Test plan
- [ ] Push a stable tag (e.g. `v0.1.44`) and verify Release uploads assets and Homebrew Tap publishes the formula.
- [ ] Push a prerelease tag (e.g. `v0.1.44.rc1`) and verify Release finalizes as a prerelease and Homebrew Tap is skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved release workflow to automatically detect and properly label pre-release versions (alpha, beta, release candidate) based on version tags.
  * Refined release distribution process to ensure stable and pre-release versions are routed through appropriate channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->