### PR TITLE
ci: add manual release workflow that bumps Cargo.toml

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,130 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 0.1.44 or 0.1.44-rc1). Without leading v.'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run: validate and show changes without committing or tagging.'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version format
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)[0-9]*)?$ ]]; then
+            echo "::error::Invalid version format: '$VERSION'. Expected X.Y.Z or X.Y.Z-(rc|alpha|beta|pre)N."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag does not already exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.validate.outputs.tag }}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::Tag ${TAG} already exists locally."
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists on origin."
+            exit 1
+          fi
+
+      - name: Setup Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Update Cargo.toml version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.validate.outputs.version }}"
+          python3 - "$VERSION" <<'PY'
+          import re, sys, pathlib
+          version = sys.argv[1]
+          path = pathlib.Path("Cargo.toml")
+          text = path.read_text()
+          # Replace the version line only inside the [package] section.
+          pattern = re.compile(
+              r'(\[package\][^\[]*?\nversion\s*=\s*)"[^"]*"',
+              re.DOTALL,
+          )
+          new_text, count = pattern.subn(rf'\1"{version}"', text, count=1)
+          if count != 1:
+              sys.exit("Failed to locate [package] version field in Cargo.toml")
+          path.write_text(new_text)
+          PY
+          echo "--- Cargo.toml diff ---"
+          git --no-pager diff -- Cargo.toml
+
+      - name: Sync Cargo.lock
+        shell: bash
+        run: cargo update -p wakezilla
+
+      - name: Show changes (dry run)
+        if: ${{ inputs.dry_run }}
+        shell: bash
+        run: |
+          echo "Dry run enabled. Changes that would be committed:"
+          git --no-pager diff -- Cargo.toml Cargo.lock
+          echo "Tag that would be created: ${{ steps.validate.outputs.tag }}"
+
+      - name: Commit and tag release
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.validate.outputs.version }}"
+          TAG="${{ steps.validate.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          if git diff --cached --quiet; then
+            echo "::error::No changes staged. Version may already be set to ${VERSION}."
+            exit 1
+          fi
+          git commit -m "chore(release): ${TAG}"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "${TAG}"
+
+      - name: Summary
+        shell: bash
+        run: |
+          {
+            echo "## Manual Release"
+            echo ""
+            echo "- **Version:** \`${{ steps.validate.outputs.version }}\`"
+            echo "- **Tag:** \`${{ steps.validate.outputs.tag }}\`"
+            echo "- **Branch:** \`${GITHUB_REF_NAME}\`"
+            echo "- **Dry run:** \`${{ inputs.dry_run }}\`"
+            if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+              echo ""
+              echo "The \`release.yml\` workflow will build and publish the release for this tag."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/manual-release.yml`, a `workflow_dispatch`-triggered pipeline that validates a semver version, bumps the `[package]` version in `Cargo.toml`, syncs `Cargo.lock`, commits the change, and pushes a `vX.Y.Z` tag.
- The pushed tag triggers the existing `release.yml` which builds cross-platform binaries and creates the GitHub Release (prerelease is auto-detected from `rc/alpha/beta/pre` suffixes).
- Includes a `dry_run` input for previewing the version bump and tag without committing or pushing.

## Usage
1. GitHub → **Actions → Manual Release → Run workflow**.
2. Enter `version` (e.g., `0.1.44` or `0.1.44-rc3`). Optionally enable `dry_run`.
3. The workflow validates the format, ensures the tag does not already exist, updates `Cargo.toml` + `Cargo.lock`, commits as `chore(release): vX.Y.Z`, then tags and pushes.

## Test plan
- [ ] Trigger with `dry_run: true` on a throwaway version to confirm the diff preview renders correctly and nothing is pushed.
- [ ] Trigger with a real prerelease version (e.g., `0.1.44-rc3`) and verify `release.yml` runs, artifacts upload, and `homebrew.yml` is skipped.
- [ ] Trigger with a stable version and verify the release is marked non-prerelease and `homebrew.yml` publishes the formula.
- [ ] Re-run with an existing tag to confirm the pre-flight check rejects it.
- [ ] Run with an invalid version string (e.g., `1.2`) and confirm validation fails early.