### PR TITLE
ci: use PAT in manual release so tag push triggers release.yml

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -24,7 +24,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT so the pushed tag triggers release.yml.
+          # The default GITHUB_TOKEN cannot trigger other workflows.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Validate version format
         id: validate


### PR DESCRIPTION
## Summary
- Replaces `GITHUB_TOKEN` with `RELEASE_PAT` in the `manual-release.yml` checkout step.
- GitHub Actions explicitly does not dispatch workflow runs for commits/tags pushed using the default `GITHUB_TOKEN` — this prevents recursive workflow chains. The result in run [24691345595](https://github.com/guibeira/wakezilla/actions/runs/24691345595) was: tag \`v0.1.45\` pushed successfully, but \`release.yml\` never fired, so no GitHub Release was created and \`homebrew.yml\` didn't trigger either.
- Using a PAT bypasses that restriction: the tag push fires \`release.yml\`, which publishes the Release and in turn triggers \`homebrew.yml\` (for stable versions).

## Required before merging
Create a repo secret named `RELEASE_PAT`:
1. GitHub → **Settings** → **Developer settings** → **Personal access tokens** → **Fine-grained** (or classic).
2. For a fine-grained token, grant **Contents: read & write** on this repo.
3. For a classic token, the `repo` scope is sufficient.
4. Add it as a repo secret: **Settings → Secrets and variables → Actions → New repository secret**, name `RELEASE_PAT`.

Reference: [GitHub docs on triggering workflows from other workflows](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).

## Follow-up
Tag \`v0.1.45\` was already pushed by the previous run but \`release.yml\` never fired for it. After this PR merges and \`RELEASE_PAT\` is set, the next manual release (e.g., \`0.1.46\` or a re-dispatch) will trigger the full chain. To backfill the missing \`v0.1.45\` release, you can re-push the tag manually (\`git push --delete origin v0.1.45 && git tag -d v0.1.45 && git tag v0.1.45 <sha> && git push origin v0.1.45\`) using local credentials, or simply cut the next release.

## Test plan
- [ ] Create the `RELEASE_PAT` secret.
- [ ] Trigger Manual Release with a throwaway prerelease (e.g., `0.1.46-rc1`) and confirm `release.yml` starts running after the tag push.
- [ ] Confirm `homebrew.yml` is skipped for the prerelease.
- [ ] Trigger Manual Release with a stable version and confirm both `release.yml` and `homebrew.yml` complete successfully.