### PR TITLE
ci: publish wakezilla to crates.io on stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,8 @@ jobs:
 
   publish-crate:
     needs: release
+    # Skip the entire job for prereleases before any environment gate fires.
+    if: ${{ !contains(github.ref, 'rc') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') && !contains(github.ref, 'pre') }}
     runs-on: ubuntu-latest
     environment: main
     permissions:
@@ -173,30 +175,45 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          if [[ "$VERSION" =~ (rc|alpha|beta|pre) ]]; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-          else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Skip prerelease
-        if: steps.tag_version.outputs.prerelease == 'true'
-        shell: bash
-        run: echo "Prerelease detected — skipping crates.io publish."
 
       - name: Checkout repository
-        if: steps.tag_version.outputs.prerelease == 'false'
         uses: actions/checkout@v4
 
+      - name: Verify tag matches Cargo.toml version
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${{ steps.tag_version.outputs.version }}"
+          MANIFEST_VERSION=$(
+            awk '
+              /^\[package\]/ { in_pkg = 1; next }
+              /^\[/          { in_pkg = 0 }
+              in_pkg && /^version[[:space:]]*=/ {
+                match($0, /"[^"]*"/)
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+              }
+            ' Cargo.toml
+          )
+          if [[ "$TAG_VERSION" != "$MANIFEST_VERSION" ]]; then
+            echo "::error::Tag version '$TAG_VERSION' does not match Cargo.toml [package] version '$MANIFEST_VERSION'."
+            exit 1
+          fi
+          echo "Tag and manifest agree on version $TAG_VERSION."
+
       - name: Setup Rust toolchain
-        if: steps.tag_version.outputs.prerelease == 'false'
         shell: bash
         run: |
           rustup toolchain install stable --profile minimal
           rustup default stable
 
+      - name: Dry-run publish
+        shell: bash
+        run: cargo publish -p wakezilla --dry-run --no-verify --token "${CARGO_REGISTRY_TOKEN}"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
       - name: Publish wakezilla to crates.io
-        if: steps.tag_version.outputs.prerelease == 'false'
         shell: bash
         run: cargo publish -p wakezilla --no-verify --token "${CARGO_REGISTRY_TOKEN}"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,3 +158,46 @@ jobs:
           prerelease: ${{ steps.tag_version.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-crate:
+    needs: release
+    runs-on: ubuntu-latest
+    environment: main
+    permissions:
+      contents: read
+
+    steps:
+      - name: Extract version from tag
+        id: tag_version
+        shell: bash
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" =~ (rc|alpha|beta|pre) ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Skip prerelease
+        if: steps.tag_version.outputs.prerelease == 'true'
+        shell: bash
+        run: echo "Prerelease detected — skipping crates.io publish."
+
+      - name: Checkout repository
+        if: steps.tag_version.outputs.prerelease == 'false'
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        if: steps.tag_version.outputs.prerelease == 'false'
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Publish wakezilla to crates.io
+        if: steps.tag_version.outputs.prerelease == 'false'
+        shell: bash
+        run: cargo publish -p wakezilla --no-verify --token "${CARGO_REGISTRY_TOKEN}"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tower = "0.5"
 tower-http  = {version = "0.6.6", features = [ "cors", "fs"] }
 mime_guess = "2.0"
 include_dir = "0.7.4"
-wakezilla-common = { path = "common" }
+wakezilla-common = { path = "common", version = "0.1.0" }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,6 +2,10 @@
 name = "wakezilla-common"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+description = "Shared types for wakezilla, a Wake-on-LAN proxy server"
+repository = "https://github.com/guibeira/wakezilla"
+homepage = "https://github.com/guibeira/wakezilla"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Adds a `publish-crate` job to `release.yml` that runs after the GitHub Release is created, skips prereleases (`rc`/`alpha`/`beta`/`pre`), and publishes `wakezilla` to crates.io using `CARGO_REGISTRY_TOKEN` from the `main` deployment environment.
- Prepares the workspace for publishing:
  - `common/Cargo.toml` gains the `license`, `description`, `repository`, and `homepage` fields required by crates.io.
  - Root `Cargo.toml` adds `version = "0.1.0"` to the `wakezilla-common` path dep so `cargo publish` can resolve it against crates.io.
- Uses `--no-verify` because the matrix build job has already compiled the binary end-to-end; a second verify pass would need nightly + trunk + wasm without adding value.

## Why this wasn't automatic before
`wakezilla` 0.1.43 was published before the workspace refactor that extracted `wakezilla-common`. Since then, no stable release has been published to crates.io because the current `Cargo.toml` would fail `cargo publish` with `all path dependencies must have a version`.

## Required manual bootstrap (one time)
After merging this PR:

1. Publish `wakezilla-common` 0.1.0 manually (it does not exist on crates.io yet):
   ```bash
   cargo publish -p wakezilla-common --token <your-crates.io-token>
   ```
2. Backfill `wakezilla` 0.1.45 manually (the Manual Release ran but crates.io publish didn't exist yet):
   ```bash
   git checkout v0.1.45
   cargo publish -p wakezilla --no-verify --token <your-crates.io-token>
   git checkout main
   ```

After this bootstrap, future stable Manual Releases will push to crates.io automatically via the new job.

## Verification done locally
- `cargo publish -p wakezilla-common --dry-run` — OK (packages 6 files, 7.3 KiB).
- `cargo publish -p wakezilla --dry-run --no-verify` — fails with the expected `no matching package named 'wakezilla-common' found` until the bootstrap completes.
- `release.yml` YAML parses clean.

## Test plan
- [ ] Complete the manual bootstrap above.
- [ ] Trigger Manual Release with a prerelease (e.g., `0.1.46-rc1`) and confirm the `publish-crate` job is skipped (no crates.io upload).
- [ ] Trigger Manual Release with a stable version (e.g., `0.1.46`) and confirm the crate appears on https://crates.io/crates/wakezilla within ~1 minute of the job completing.
- [ ] Confirm `homebrew.yml` still publishes the tap formula after the release job finishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated publishing to crates.io for new releases
  * Enhanced package metadata with license, description, repository, and homepage information for improved discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->