### PR TITLE
ci: add one-shot bootstrap-publish workflow

### DIFF
--- a/.github/workflows/bootstrap-publish.yml
+++ b/.github/workflows/bootstrap-publish.yml
@@ -1,0 +1,76 @@
+name: Bootstrap Publish
+
+# One-shot workflow to publish wakezilla-common to crates.io (which has never
+# been published) and optionally re-publish wakezilla from a specific tag.
+# Designed to unblock the publish-crate job in release.yml when the helper
+# crate is missing from the registry.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to publish from (branch or tag, e.g., v0.1.46).'
+        required: true
+        type: string
+        default: 'main'
+      publish_common:
+        description: 'Publish wakezilla-common.'
+        required: false
+        type: boolean
+        default: true
+      publish_wakezilla:
+        description: 'Publish wakezilla after wakezilla-common is available.'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    environment: main
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Publish wakezilla-common
+        if: ${{ inputs.publish_common }}
+        shell: bash
+        run: cargo publish -p wakezilla-common --token "${CARGO_REGISTRY_TOKEN}"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for wakezilla-common on crates.io index
+        if: ${{ inputs.publish_common && inputs.publish_wakezilla }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            body=$(curl -sfL -H "User-Agent: wakezilla-ci" \
+              "https://crates.io/api/v1/crates/wakezilla-common" || true)
+            if echo "$body" | grep -q '"name":"wakezilla-common"'; then
+              echo "wakezilla-common is indexed on crates.io"
+              exit 0
+            fi
+            echo "Attempt $i: not indexed yet, sleeping 10s..."
+            sleep 10
+          done
+          echo "::error::Timed out waiting for wakezilla-common to appear on the crates.io index."
+          exit 1
+
+      - name: Publish wakezilla
+        if: ${{ inputs.publish_wakezilla }}
+        shell: bash
+        run: cargo publish -p wakezilla --no-verify --token "${CARGO_REGISTRY_TOKEN}"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
Publishes \`wakezilla-common\` to crates.io (never published before) and optionally backfills \`wakezilla\` from a specific tag — unblocking the \`publish-crate\` job in \`release.yml\` that is currently failing with \`no matching package named wakezilla-common\`.

## Usage
After this merges, dispatch from **Actions → Bootstrap Publish → Run workflow**:
- \`ref\`: \`v0.1.46\` (backfills the release that already has a GitHub Release but no crates.io entry).
- \`publish_common\`: ✅ true (first run only).
- \`publish_wakezilla\`: ✅ true.

On subsequent runs (if ever needed), set \`publish_common\` false to skip the helper crate and just republish wakezilla from another tag.

## What it does
1. Checks out the specified ref.
2. Installs stable Rust (minimal profile).
3. Runs \`cargo publish -p wakezilla-common --token \$CARGO_REGISTRY_TOKEN\` (verify on, it's tiny).
4. Polls the crates.io index until \`wakezilla-common\` appears (~10s granularity, up to 5 min).
5. Runs \`cargo publish -p wakezilla --no-verify --token \$CARGO_REGISTRY_TOKEN\`.

Uses the existing \`main\` environment for access to \`CARGO_REGISTRY_TOKEN\` — same secret path as \`release.yml\`.

## Test plan
- [ ] Merge.
- [ ] Dispatch with \`ref=v0.1.46\`, both toggles on.
- [ ] Confirm https://crates.io/crates/wakezilla-common 0.1.0 is live.
- [ ] Confirm https://crates.io/crates/wakezilla 0.1.46 is live.
- [ ] Next stable Manual Release (e.g., 0.1.47) runs through \`publish-crate\` cleanly without this workflow.

## Cleanup
Workflow is safe to leave in place — it only runs on manual dispatch and is useful as a break-glass for future republish scenarios. If you'd rather remove it after the bootstrap, open a follow-up PR deleting \`.github/workflows/bootstrap-publish.yml\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release workflow for publishing packages with manual trigger controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->