### PR TITLE
ci: auto-generate release notes from merged PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,19 +138,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           name: Release ${{ steps.tag_version.outputs.version }}
-          body: |
-            ## Release ${{ steps.tag_version.outputs.version }}
-            
-            ### Downloads
-            - **Linux (x86_64)**: `wakezilla-${{ steps.tag_version.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz`
-            - **macOS (x86_64)**: `wakezilla-${{ steps.tag_version.outputs.version }}-x86_64-apple-darwin.tar.gz`
-            - **macOS (ARM64)**: `wakezilla-${{ steps.tag_version.outputs.version }}-aarch64-apple-darwin.tar.gz`
-            
-            ### Installation
-            Extract the archive for your platform and run the binary.
-            
-            ### Changes
-            See [commit history](https://github.com/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.ref }}) for details.
+          generate_release_notes: true
           files: |
             release/*.tar.gz
             release/SHA256SUMS


### PR DESCRIPTION
## Summary
Replaces the hand-rolled body in the `Create GitHub Release` step with `generate_release_notes: true` so future releases get the same "What's Changed" / "New Contributors" / "Full Changelog" layout as [v0.1.43](https://github.com/guibeira/wakezilla/releases/tag/v0.1.43), populated from the PRs merged between the previous tag and the new one.

## Why
The previous body also rendered a broken compare link (e.g., on [v0.1.46](https://github.com/guibeira/wakezilla/releases/tag/v0.1.46)) because `github.event.before` is empty on `push: tags`.

The Downloads/Installation section is removed — GitHub already shows the attached `tar.gz` and `SHA256SUMS` assets on the release page, and v0.1.43 didn't have it either.

## Test plan
- [ ] Trigger a Manual Release (e.g., `0.1.47`) once this PR merges and confirm the release body lists merged PRs in "What's Changed" with a "Full Changelog" link at the bottom.