### PR TITLE
fix packaged frontend assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,29 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
+      - name: Setup frontend build toolchain
+        shell: bash
+        run: |
+          rustup toolchain install nightly --allow-downgrade
+          rustup target add wasm32-unknown-unknown --toolchain nightly
+          cargo install trunk --locked
+          cargo install wasm-bindgen-cli --locked
+
+      - name: Build packaged frontend assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf frontend-dist
+          cd frontend
+          trunk build --release --dist ../frontend-dist
+          test -f ../frontend-dist/index.html
+
+      - name: Verify frontend assets are packaged
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo package -p wakezilla --list --allow-dirty | grep '^frontend-dist/index.html$'
+
       - name: Dry-run publish
         shell: bash
         run: cargo publish -p wakezilla --dry-run --no-verify --token "${CARGO_REGISTRY_TOKEN}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 frontend/target
 dist
+frontend-dist
 machines.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ include = [
     "frontend/src/**",
     "frontend/style/**",
     "frontend/public/**",
+    "frontend-dist/**",
     "build.rs",
     "common/Cargo.toml",
     "common/src/**",

--- a/build.rs
+++ b/build.rs
@@ -11,9 +11,11 @@ fn main() {
     println!("cargo:rerun-if-changed=frontend/Cargo.toml");
     println!("cargo:rerun-if-changed=frontend/Cargo.lock");
     println!("cargo:rerun-if-changed=frontend/public");
+    println!("cargo:rerun-if-changed=frontend-dist");
 
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("missing CARGO_MANIFEST_DIR");
     let frontend_dir = Path::new(&manifest_dir).join("frontend");
+    let prebuilt_frontend_dist_dir = Path::new(&manifest_dir).join("frontend-dist");
     let cargo_target_dir = env::var("CARGO_TARGET_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| Path::new(&manifest_dir).join("target"));
@@ -34,8 +36,16 @@ fn main() {
     }
 
     if !frontend_dir.is_dir() {
-        create_placeholder_frontend(&frontend_dist_dir);
-        return;
+        if prebuilt_frontend_dist_dir.join("index.html").is_file() {
+            copy_dir_all(&prebuilt_frontend_dist_dir, &frontend_dist_dir);
+            return;
+        }
+
+        panic!(
+            "frontend assets not found: expected either `{}` or `{}`",
+            frontend_dir.display(),
+            prebuilt_frontend_dist_dir.join("index.html").display()
+        );
     }
 
     ensure_tool_or_install("trunk", &["install", "trunk", "--locked"]);
@@ -88,23 +98,51 @@ fn main() {
     );
 }
 
-fn create_placeholder_frontend(frontend_dist_dir: &Path) {
-    fs::create_dir_all(frontend_dist_dir).unwrap_or_else(|err| {
+fn copy_dir_all(src: &Path, dst: &Path) {
+    if dst.exists() {
+        fs::remove_dir_all(dst).unwrap_or_else(|err| {
+            panic!(
+                "failed to clean frontend dist directory `{}`: {err}",
+                dst.display()
+            )
+        });
+    }
+
+    fs::create_dir_all(dst).unwrap_or_else(|err| {
         panic!(
             "failed to create frontend dist directory `{}`: {err}",
-            frontend_dist_dir.display()
+            dst.display()
         )
     });
-    fs::write(
-        frontend_dist_dir.join("index.html"),
-        "<!doctype html><html><body><h1>Wakezilla</h1><p>Frontend assets are unavailable in this source package.</p></body></html>",
-    )
-    .unwrap_or_else(|err| {
+
+    for entry in fs::read_dir(src).unwrap_or_else(|err| {
         panic!(
-            "failed to write placeholder frontend index at `{}`: {err}",
-            frontend_dist_dir.display()
+            "failed to read frontend dist directory `{}`: {err}",
+            src.display()
         )
-    });
+    }) {
+        let entry = entry.expect("failed to read frontend dist entry");
+        let file_type = entry.file_type().unwrap_or_else(|err| {
+            panic!(
+                "failed to read file type for frontend asset `{}`: {err}",
+                entry.path().display()
+            )
+        });
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+
+        if file_type.is_dir() {
+            copy_dir_all(&from, &to);
+        } else {
+            fs::copy(&from, &to).unwrap_or_else(|err| {
+                panic!(
+                    "failed to copy frontend asset `{}` to `{}`: {err}",
+                    from.display(),
+                    to.display()
+                )
+            });
+        }
+    }
 }
 
 fn ensure_tool_or_install(tool: &str, cargo_install_args: &[&str]) {


### PR DESCRIPTION
Fixes #34.

## Summary

Fixes the crates.io packaging path so release builds published from CI include the built web UI instead of embedding the placeholder page.

## Root cause

The published crate source does not include the `frontend/` workspace member. When users install with `cargo install wakezilla`, `build.rs` currently falls back to generating `Frontend assets are unavailable in this source package.`, and that placeholder is embedded into the binary.

## Changes

- Include `frontend-dist/**` in the published crate package.
- Update `build.rs` to use prebuilt `frontend-dist/` assets when `frontend/` source is unavailable, and fail loudly if neither exists.
- Generate and verify `frontend-dist/` in the release workflow before `cargo publish`.
- Ignore local `frontend-dist/` output so generated assets do not need to be committed.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo package -p wakezilla --list --allow-dirty`
- `cargo package -p wakezilla --allow-dirty --no-verify`
- Extracted the generated `.crate`, built it in Docker without `frontend/`, ran `wakezilla proxy-server`, and verified `/` serves the real frontend instead of the placeholder.
- `cargo test --workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process with automated frontend asset verification and validation
  * Enhanced build system to use prebuilt frontend resources
  * Updated packaging to ensure frontend distribution artifacts are included in releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->