### PR TITLE
Optimize CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,56 +5,75 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  build:
+  fmt:
+    name: fmt
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🔧 Setup Rust toolchain (nightly) and wasm target
-        run: rustup toolchain install nightly --allow-downgrade
-
-      - name: Setup Rust toolchain and wasm target
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: ⚡ Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            . frontend
-
-      - name: Cache Cargo bin directory
-        uses: actions/cache@v4
-        id: cache-cargo-bin
-        with:
-          path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-bin-v1
-          restore-keys: |
-            ${{ runner.os }}-cargo-bin-
-
-      - name: Install Trunk
-        if: steps.cache-cargo-bin.outputs.cache-hit != 'true'
-        run: |
-          if ! command -v trunk &> /dev/null; then
-            cargo install trunk
-          fi
-
-      - name: Install Tarpaulin
-        if: steps.cache-cargo-bin.outputs.cache-hit != 'true'
-        run: |
-          if ! command -v cargo-tarpaulin &> /dev/null; then
-            cargo install cargo-tarpaulin
-          fi
-
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  frontend:
+    name: frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup nightly Rust toolchain and wasm target
+        run: rustup toolchain install nightly --profile minimal --target wasm32-unknown-unknown --allow-downgrade
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: frontend
+
+      - name: Install Trunk
+        uses: taiki-e/install-action@v2
+        with:
+          tool: trunk
+
       - name: Build frontend
+        env:
+          NO_COLOR: "true"
         run: cd frontend && trunk build --release
 
-      - name: Run tests with tarpaulin
-        env:
-          RUSTFLAGS: -C debuginfo=2
-        run: cargo tarpaulin --workspace --timeout 180 --out Xml
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            frontend
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Prepare frontend assets for backend tests
+        run: |
+          mkdir -p target/frontend-dist target/llvm-cov-target/frontend-dist
+          printf '<!doctype html><html><head><title>wakezilla</title></head><body></body></html>\n' | tee target/frontend-dist/index.html > target/llvm-cov-target/frontend-dist/index.html
+
+      - name: Run tests with cargo-llvm-cov
+        run: cargo llvm-cov --workspace --cobertura --output-path cobertura.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Build frontend
         env:
           NO_COLOR: "true"
+          RUSTUP_TOOLCHAIN: nightly
         run: cd frontend && trunk build --release
 
   coverage:

--- a/Tarpaulin.toml
+++ b/Tarpaulin.toml
@@ -1,3 +1,0 @@
-[config]
-skip-clean = true
-offline = true


### PR DESCRIPTION
## Summary

- Split the CI workflow into parallel `fmt`, `frontend`, and `coverage` jobs.
- Replace source-built Trunk/Tarpaulin installs with prebuilt tooling via `taiki-e/install-action`.
- Replace Tarpaulin coverage with `cargo-llvm-cov` producing Cobertura XML.
- Add cancellation for superseded CI runs and remove the obsolete `Tarpaulin.toml` config.

## Why

The referenced Actions run spent most of its time compiling CI tools from source: Trunk took about 5m18s and Tarpaulin took about 2m29s before project validation could run. The new workflow removes that cold install cost and lets independent checks run concurrently.

## Validation

- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/ci.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `cargo fmt --all -- --check`
- `cargo llvm-cov --workspace --cobertura --output-path cobertura.xml`
- `NO_COLOR=true trunk build --release`