### PR TITLE
Fix release frontend toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,8 @@ jobs:
 
       - name: Build packaged frontend assets
         shell: bash
+        env:
+          RUSTUP_TOOLCHAIN: nightly
         run: |
           set -euo pipefail
           rm -rf frontend-dist

--- a/build.rs
+++ b/build.rs
@@ -88,6 +88,7 @@ fn main() {
         Some("frontend"),
         &[
             ("NO_COLOR", "true"),
+            ("RUSTUP_TOOLCHAIN", "nightly"),
             (
                 "CARGO_TARGET_DIR",
                 frontend_build_target_dir


### PR DESCRIPTION
## Summary
- Run the packaged frontend build in the release publish job with the nightly toolchain.
- Pass `RUSTUP_TOOLCHAIN=nightly` when `build.rs` invokes `trunk`.

## Root cause
The publish job installed `wasm32-unknown-unknown` for `nightly`, but `trunk build` used the default stable toolchain. Cargo then could not find `core` for the wasm target.

## Validation
- `docker run --rm -v "$PWD":/work -w /work rust:bookworm bash -c 'set -euo pipefail; rustup toolchain install stable --profile minimal; rustup default stable; rustup toolchain install nightly --allow-downgrade; rustup target add wasm32-unknown-unknown --toolchain nightly; cargo install trunk --locked; cargo install wasm-bindgen-cli --locked; rm -rf frontend-dist; cd frontend; RUSTUP_TOOLCHAIN=nightly trunk build --release --dist ../frontend-dist; test -f ../frontend-dist/index.html'`
- `docker run --rm -v "$PWD":/work -w /work rust:bookworm bash -c "cargo package -p wakezilla --list --allow-dirty | grep '^frontend-dist/index.html$'"`
- `docker run --rm -v "$PWD":/work -w /work rust:bookworm cargo check -p wakezilla --all-targets`
- `docker run --rm -v "$PWD":/work -w /work rust:bookworm bash -c 'set -euo pipefail; rustup component add rustfmt; cargo fmt --all -- --check'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use nightly toolchain for frontend asset compilation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->