### PR TITLE
Fix release publish for generated frontend assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,12 +222,12 @@ jobs:
 
       - name: Dry-run publish
         shell: bash
-        run: cargo publish -p wakezilla --dry-run --no-verify --token "${CARGO_REGISTRY_TOKEN}"
+        run: cargo publish -p wakezilla --dry-run --no-verify --allow-dirty --token "${CARGO_REGISTRY_TOKEN}"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Publish wakezilla to crates.io
         shell: bash
-        run: cargo publish -p wakezilla --no-verify --token "${CARGO_REGISTRY_TOKEN}"
+        run: cargo publish -p wakezilla --no-verify --allow-dirty --token "${CARGO_REGISTRY_TOKEN}"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `--allow-dirty` to both publish commands in the release workflow.
- Keep generated `frontend-dist` assets included in the crate package after the workflow builds them.

## Root cause
The release job builds `frontend-dist` during the job. `cargo publish` then sees those generated files as uncommitted working tree changes and fails unless dirty packaging is explicitly allowed.

## Validation
- `git diff --check`
- `docker run --rm -v "$PWD":/work -w /work rust:bookworm bash -c 'set -euo pipefail; rustup component add rustfmt >/dev/null 2>&1 || true; cargo fmt --all -- --check'`
- `docker run --rm -v "$PWD":/work -w /work rust:bookworm bash -c 'set -euo pipefail; rm -rf frontend-dist; mkdir -p frontend-dist/images; printf "<!doctype html><html></html>\n" > frontend-dist/index.html; printf "placeholder\n" > frontend-dist/main.css; cargo package -p wakezilla --list --allow-dirty | grep "^frontend-dist/index.html$"; cargo publish -p wakezilla --dry-run --no-verify --allow-dirty'`