### PR TITLE
superseded: publish Homebrew formula after release

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,15 +1,18 @@
 name: Homebrew Tap
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish to Homebrew, e.g. v0.1.49.'
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   publish:
-    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repository
@@ -17,12 +20,23 @@ jobs:
         with:
           path: source
 
+      - name: Verify Homebrew tap token is configured
+        shell: bash
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOMEBREW_TAP_GITHUB_TOKEN}" ]; then
+            echo "::error::Missing HOMEBREW_TAP_GITHUB_TOKEN. Create a token with Contents: read/write on guibeira/homebrew-wakezilla and add it as a repository secret."
+            exit 1
+          fi
+
       - name: Download release checksums
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${{ inputs.tag }}"
           mkdir -p source/release
           cd source/release
           gh release download "${TAG}" -p "SHA256SUMS"
@@ -37,8 +51,13 @@ jobs:
       - name: Generate formula
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${{ inputs.tag }}"
           VERSION="${TAG#v}"
+          if [[ "$VERSION" =~ (rc|alpha|beta|pre) ]]; then
+            echo "::error::Homebrew publishes stable releases only: ${TAG}"
+            exit 1
+          fi
+          mkdir -p tap/Formula
           bash source/scripts/release/generate_homebrew_formula.sh \
             "${VERSION}" \
             source/release/SHA256SUMS \
@@ -49,6 +68,8 @@ jobs:
       - name: Commit and push formula
         run: |
           set -euo pipefail
+          VERSION="${{ inputs.tag }}"
+          VERSION="${VERSION#v}"
           cd tap
           git add Formula/wakezilla.rb
           if git diff --cached --quiet -- Formula/wakezilla.rb; then
@@ -57,5 +78,5 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "release: wakezilla ${GITHUB_REF_NAME#v}"
+          git commit -m "release: wakezilla ${VERSION}"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.tag_version.outputs.version }}
+      prerelease: ${{ steps.tag_version.outputs.prerelease }}
     
     steps:
       - name: Checkout repository
@@ -146,6 +149,74 @@ jobs:
           prerelease: ${{ steps.tag_version.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-homebrew:
+    needs: release
+    # Homebrew should track stable releases only.
+    if: ${{ needs.release.outputs.prerelease == 'false' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+        with:
+          path: source
+
+      - name: Verify Homebrew tap token is configured
+        shell: bash
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOMEBREW_TAP_GITHUB_TOKEN}" ]; then
+            echo "::error::Missing HOMEBREW_TAP_GITHUB_TOKEN. Create a token with Contents: read/write on guibeira/homebrew-wakezilla and add it as a repository secret."
+            exit 1
+          fi
+
+      - name: Download release checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          mkdir -p source/release
+          cd source/release
+          gh release download "${TAG}" -p "SHA256SUMS"
+
+      - name: Checkout tap repository
+        uses: actions/checkout@v4
+        with:
+          repository: guibeira/homebrew-wakezilla
+          token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          path: tap
+
+      - name: Generate formula
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.release.outputs.version }}"
+          mkdir -p tap/Formula
+          bash source/scripts/release/generate_homebrew_formula.sh \
+            "${VERSION}" \
+            source/release/SHA256SUMS \
+            tap/Formula/wakezilla.rb \
+            guibeira \
+            wakezilla
+
+      - name: Commit and push formula
+        run: |
+          set -euo pipefail
+          cd tap
+          git add Formula/wakezilla.rb
+          if git diff --cached --quiet -- Formula/wakezilla.rb; then
+            echo "No formula changes; skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "release: wakezilla ${{ needs.release.outputs.version }}"
+          git push
 
   publish-crate:
     needs: release


### PR DESCRIPTION
Superseded by #42, which keeps the Homebrew tap in this repository instead of using a separate tap repository.