### PR TITLE
fix(release): publish Homebrew formula from main repo

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -19,17 +19,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: source
-
-      - name: Verify Homebrew tap token is configured
-        shell: bash
-        env:
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${HOMEBREW_TAP_GITHUB_TOKEN}" ]; then
-            echo "::error::Missing HOMEBREW_TAP_GITHUB_TOKEN. Create a token with Contents: read/write on guibeira/homebrew-wakezilla and add it as a repository secret."
-            exit 1
-          fi
 
       - name: Download release checksums
         env:
@@ -41,11 +30,10 @@ jobs:
           cd source/release
           gh release download "${TAG}" -p "SHA256SUMS"
 
-      - name: Checkout tap repository
+      - name: Checkout repository tap
         uses: actions/checkout@v4
         with:
-          repository: guibeira/homebrew-wakezilla
-          token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          ref: ${{ github.event.repository.default_branch }}
           path: tap
 
       - name: Generate formula
@@ -79,4 +67,4 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "release: wakezilla ${VERSION}"
-          git push
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,24 +156,13 @@ jobs:
     if: ${{ needs.release.outputs.prerelease == 'false' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
           path: source
-
-      - name: Verify Homebrew tap token is configured
-        shell: bash
-        env:
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${HOMEBREW_TAP_GITHUB_TOKEN}" ]; then
-            echo "::error::Missing HOMEBREW_TAP_GITHUB_TOKEN. Create a token with Contents: read/write on guibeira/homebrew-wakezilla and add it as a repository secret."
-            exit 1
-          fi
 
       - name: Download release checksums
         env:
@@ -185,11 +174,10 @@ jobs:
           cd source/release
           gh release download "${TAG}" -p "SHA256SUMS"
 
-      - name: Checkout tap repository
+      - name: Checkout repository tap
         uses: actions/checkout@v4
         with:
-          repository: guibeira/homebrew-wakezilla
-          token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          ref: ${{ github.event.repository.default_branch }}
           path: tap
 
       - name: Generate formula
@@ -216,7 +204,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "release: wakezilla ${{ needs.release.outputs.version }}"
-          git push
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"
 
   publish-crate:
     needs: release

--- a/Formula/wakezilla.rb
+++ b/Formula/wakezilla.rb
@@ -1,0 +1,24 @@
+class Wakezilla < Formula
+  desc "Wake-on-LAN proxy server written in Rust"
+  homepage "https://github.com/guibeira/wakezilla"
+  version "0.1.49"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/guibeira/wakezilla/releases/download/v0.1.49/wakezilla-0.1.49-aarch64-apple-darwin.tar.gz"
+      sha256 "8756f694f2dc42ea880346881637ec4db7f22f1dcd431ae6d4e87c0badc4fe2a"
+    else
+      url "https://github.com/guibeira/wakezilla/releases/download/v0.1.49/wakezilla-0.1.49-x86_64-apple-darwin.tar.gz"
+      sha256 "003d1f8e2ba0c5e6ec4db6acd98af4fae76bbfbfbea33900bb568bbe9954da1f"
+    end
+  end
+
+  on_linux do
+    url "https://github.com/guibeira/wakezilla/releases/download/v0.1.49/wakezilla-0.1.49-x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "82e5070be07afec88720401886b17721f8a8daab1937aad452082b208f0cef14"
+  end
+
+  def install
+    bin.install "wakezilla"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo install wakezilla
 ### Install via Homebrew
 
 ```bash
-brew tap guibeira/wakezilla
+brew tap guibeira/wakezilla https://github.com/guibeira/wakezilla
 brew install wakezilla
 ```
 


### PR DESCRIPTION
## Summary

- Add `Formula/wakezilla.rb` for the current `v0.1.49` release so the repository can be used as its own Homebrew tap immediately.
- Update the release workflow to regenerate and commit `Formula/wakezilla.rb` back to the default branch after each stable release.
- Keep the Homebrew workflow as a manual backfill path for an existing stable tag.
- Update the README to tap this repository directly with an explicit URL.

## Behavior

Stable releases update the formula after release assets and `SHA256SUMS` are available. Prerelease tags remain skipped for Homebrew.

Because the tap now lives in this repository, no separate tap repository or `HOMEBREW_TAP_GITHUB_TOKEN` secret is required. The workflow uses the repository `GITHUB_TOKEN` with `contents: write`.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/release.yml .github/workflows/homebrew.yml`
- `bash -n scripts/release/generate_homebrew_formula.sh`
- `ruby -c Formula/wakezilla.rb`
- `git diff --check`