### PR TITLE
docs: point install script to wakezilla.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@
 ### Install with script
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/guibeira/wakezilla/main/install.sh | sh
+curl -fsSL https://wakezilla.dev/install.sh | sh
 ```
 
 To pin a version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/guibeira/wakezilla/main/install.sh | sh -s -- 0.1.49
+curl -fsSL https://wakezilla.dev/install.sh | sh -s -- 0.1.49
 ```
 
 By default this installs `wakezilla` to `$HOME/.local/bin`. Override the destination with `BIN_DIR`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/guibeira/wakezilla/main/install.sh | BIN_DIR=/usr/local/bin sh -s -- 0.1.49
+curl -fsSL https://wakezilla.dev/install.sh | BIN_DIR=/usr/local/bin sh -s -- 0.1.49
 ```
 
 The script installs prebuilt binaries from GitHub Releases and requires `curl`, `jq`, `tar`, and either `sha256sum` or `shasum`.


### PR DESCRIPTION
Updates README install commands to use `https://wakezilla.dev/install.sh` instead of the raw GitHub URL.

All three install snippets updated:
- Default install
- Pinned version
- `BIN_DIR` override