### PR TITLE
feat: add setup subcommand for system service auto-start + service control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4289,6 +4289,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio 1.47.1",
+ "toml 0.8.23",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ regex = "1.11.2"
 once_cell = "1.19.0"
 anyhow = "1.0"
 config = { version = "0.14", features = ["toml", "yaml", "json"] }
+toml = "0.8"
 tower = "0.5"
 tower-http  = {version = "0.6.6", features = [ "cors", "fs"] }
 mime_guess = "2.0"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ docker run -d \
    You can check the health of the client server by visiting:
    http://<client-ip>:3001/health
 
+### Set up auto-start (system service)
+
+1. **Run the interactive setup wizard** (requires `sudo`/admin privileges):
+   ```bash
+    sudo wakezilla setup
+   ```
+
+   This interactively configures the host to auto-start the proxy or client
+   server as a system service (systemd on Linux, launchd on macOS, or the
+   Windows Service Manager). It writes an OS-standard config file, installs and
+   enables the service, then validates that the service is reachable after
+   install. Pass `--mode <proxy|client>` and `--port <PORT>` to skip the prompts.
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ docker run -d \
    enables the service, then validates that the service is reachable after
    install. Pass `--mode <proxy|client>` and `--port <PORT>` to skip the prompts.
 
+   If a configuration or service already exists, `setup` shows a summary of the
+   current config (and installed services) and asks for confirmation before
+   overwriting. Existing settings for the *other* server are preserved — only
+   the target server's port is updated. Pass `-y`/`--yes` to skip the
+   confirmation for non-interactive use.
+
 2. **Control an installed service** (requires `sudo`/admin privileges):
    ```bash
     sudo wakezilla service start

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ docker run -d \
    enables the service, then validates that the service is reachable after
    install. Pass `--mode <proxy|client>` and `--port <PORT>` to skip the prompts.
 
+2. **Control an installed service** (requires `sudo`/admin privileges):
+   ```bash
+    sudo wakezilla service start
+    sudo wakezilla service stop
+    sudo wakezilla service restart
+   ```
+
+   Starts, stops, or restarts a service previously installed with `setup`. If
+   both the proxy and client are installed, an interactive picker asks which to
+   act on; pass `--mode <proxy|client>` to skip the prompt. If only one is
+   installed, it is selected automatically.
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -153,10 +153,8 @@ docker run -d \
    selected automatically.
 
    `logs` reads from journald on Linux and from the daemon's redirected log file
-   on macOS (`/Library/Logs/wakezilla/`). Log capture on macOS requires the
-   redirect added to the launchd plist — if you installed before this was added,
-   re-run `sudo wakezilla setup` once to enable it. Log streaming is not
-   captured for the Windows service.
+   on macOS (`/Library/Logs/wakezilla/`). Log streaming is not captured for the
+   Windows service.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -142,12 +142,21 @@ docker run -d \
     sudo wakezilla service start
     sudo wakezilla service stop
     sudo wakezilla service restart
+    sudo wakezilla service status            # is it running?
+    sudo wakezilla service logs              # status + recent logs
+    sudo wakezilla service logs -f -n 100    # follow, last 100 lines
    ```
 
-   Starts, stops, or restarts a service previously installed with `setup`. If
-   both the proxy and client are installed, an interactive picker asks which to
-   act on; pass `--mode <proxy|client>` to skip the prompt. If only one is
-   installed, it is selected automatically.
+   Controls a service previously installed with `setup`. If both the proxy and
+   client are installed, an interactive picker asks which to act on; pass
+   `--mode <proxy|client>` to skip the prompt. If only one is installed, it is
+   selected automatically.
+
+   `logs` reads from journald on Linux and from the daemon's redirected log file
+   on macOS (`/Library/Logs/wakezilla/`). Log capture on macOS requires the
+   redirect added to the launchd plist — if you installed before this was added,
+   re-run `sudo wakezilla setup` once to enable it. Log streaming is not
+   captured for the Windows service.
 
 
 ## Usage

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,7 +103,15 @@ impl Config {
 
     /// Load config from the OS-standard path, falling back to defaults on error.
     pub fn load() -> Self {
-        Self::load_from(&config_path()).unwrap_or_default()
+        let path = config_path();
+        Self::load_from(&path).unwrap_or_else(|e| {
+            tracing::warn!(
+                "Failed to load configuration from {}: {} - using defaults",
+                path.display(),
+                e
+            );
+            Self::default()
+        })
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,8 @@ pub struct Config {
 
 impl Config {
     /// Load configuration from environment variables
+    // Retained as public env-based loader; used by tests and as library API.
+    #[allow(dead_code)]
     pub fn from_env() -> Result<Self, config::ConfigError> {
         config::Config::builder()
             .add_source(
@@ -62,8 +64,7 @@ pub fn config_dir() -> PathBuf {
     }
     #[cfg(target_os = "windows")]
     {
-        let base = std::env::var("ProgramData")
-            .unwrap_or_else(|_| "C:\\ProgramData".to_string());
+        let base = std::env::var("ProgramData").unwrap_or_else(|_| "C:\\ProgramData".to_string());
         PathBuf::from(base).join("wakezilla")
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@
 //! - Validates configuration at runtime
 
 use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 
 /// Default configuration file path for machines database
 pub const DEFAULT_MACHINES_DB_PATH: &str = "machines.json";
@@ -46,6 +47,63 @@ impl Config {
             )
             .build()?
             .try_deserialize()
+    }
+}
+
+/// OS-standard directory for the Wakezilla system config file.
+pub fn config_dir() -> PathBuf {
+    #[cfg(target_os = "linux")]
+    {
+        PathBuf::from("/etc/wakezilla")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/Library/Application Support/wakezilla")
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let base = std::env::var("ProgramData")
+            .unwrap_or_else(|_| "C:\\ProgramData".to_string());
+        PathBuf::from(base).join("wakezilla")
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        PathBuf::from("/etc/wakezilla")
+    }
+}
+
+/// Full path to the system config file.
+pub fn config_path() -> PathBuf {
+    config_dir().join("config.toml")
+}
+
+impl Config {
+    /// Serialize this config to a TOML file, creating parent directories.
+    pub fn save_to(&self, path: &Path) -> Result<(), anyhow::Error> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let toml_str = toml::to_string_pretty(self)?;
+        std::fs::write(path, toml_str)?;
+        Ok(())
+    }
+
+    /// Load config from a TOML file (optional) merged with `WAKEZILLA__*` env vars.
+    pub fn load_from(path: &Path) -> Result<Self, config::ConfigError> {
+        config::Config::builder()
+            .add_source(config::File::from(path).required(false))
+            .add_source(
+                config::Environment::with_prefix("WAKEZILLA")
+                    .separator("__")
+                    .try_parsing(true),
+            )
+            .build()?
+            .try_deserialize()
+    }
+
+    /// Load config from the OS-standard path, falling back to defaults on error.
+    pub fn load() -> Self {
+        Self::load_from(&config_path()).unwrap_or_default()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod forward;
 pub mod proxy_server;
 pub mod scanner;
 pub mod service;
+pub mod setup;
 pub mod system;
 pub mod web;
 pub mod wol;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod forward;
 pub mod proxy_server;
 pub mod scanner;
+pub mod service;
 pub mod system;
 pub mod web;
 pub mod wol;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod forward;
 mod proxy_server;
 mod scanner;
+mod service;
 mod system;
 mod tui;
 mod web;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ pub enum Commands {
     Tui(TuiArgs),
     /// Configure this host to auto-start a Wakezilla server as a system service
     Setup(SetupArgs),
-    /// Start, stop, or restart an installed Wakezilla service
+    /// Control an installed Wakezilla service (start/stop/restart/status/logs)
     Service(ServiceArgs),
 }
 
@@ -331,5 +331,46 @@ mod cli_tests {
     fn cli_rejects_service_subcommand_without_action() {
         let result = Cli::try_parse_from(["wakezilla", "service"]);
         assert!(result.is_err(), "service requires an action argument");
+    }
+
+    #[test]
+    fn cli_accepts_service_logs_with_follow_and_lines() {
+        use setup::ServiceAction;
+        let cli = Cli::try_parse_from([
+            "wakezilla",
+            "service",
+            "logs",
+            "--follow",
+            "--lines",
+            "100",
+            "--mode",
+            "proxy",
+        ])
+        .expect("service logs parses");
+
+        match cli.command {
+            Commands::Service(args) => {
+                assert_eq!(args.action, ServiceAction::Logs);
+                assert!(args.follow);
+                assert_eq!(args.lines, Some(100));
+                assert_eq!(args.mode.as_deref(), Some("proxy"));
+            }
+            other => panic!("expected Service command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_service_status() {
+        use setup::ServiceAction;
+        let cli =
+            Cli::try_parse_from(["wakezilla", "service", "status"]).expect("service status parses");
+        match cli.command {
+            Commands::Service(args) => {
+                assert_eq!(args.action, ServiceAction::Status);
+                assert!(!args.follow);
+                assert!(args.lines.is_none());
+            }
+            other => panic!("expected Service command, got {other:?}"),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod web;
 mod wol;
 
 pub use api_models::*;
-use setup::SetupArgs;
+use setup::{ServiceArgs, SetupArgs};
 
 /// Simple Wake-on-LAN sender + post-WOL reachability check.
 #[derive(Parser, Debug)]
@@ -39,6 +39,8 @@ pub enum Commands {
     Tui(TuiArgs),
     /// Configure this host to auto-start a Wakezilla server as a system service
     Setup(SetupArgs),
+    /// Start, stop, or restart an installed Wakezilla service
+    Service(ServiceArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -156,6 +158,12 @@ async fn main() -> Result<()> {
         Commands::Setup(args) => {
             if let Err(e) = setup::run(args) {
                 error!("Setup error: {}", e);
+                std::process::exit(1);
+            }
+        }
+        Commands::Service(args) => {
+            if let Err(e) = setup::run_service(args) {
+                error!("Service error: {}", e);
                 std::process::exit(1);
             }
         }
@@ -288,5 +296,40 @@ mod cli_tests {
             }
             other => panic!("expected Setup command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn cli_accepts_service_subcommand_with_action_and_mode() {
+        use setup::ServiceAction;
+        let cli = Cli::try_parse_from(["wakezilla", "service", "stop", "--mode", "client"])
+            .expect("service subcommand parses");
+
+        match cli.command {
+            Commands::Service(args) => {
+                assert_eq!(args.action, ServiceAction::Stop);
+                assert_eq!(args.mode.as_deref(), Some("client"));
+            }
+            other => panic!("expected Service command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_service_subcommand_without_mode() {
+        use setup::ServiceAction;
+        let cli = Cli::try_parse_from(["wakezilla", "service", "restart"])
+            .expect("bare service action parses");
+        match cli.command {
+            Commands::Service(args) => {
+                assert_eq!(args.action, ServiceAction::Restart);
+                assert!(args.mode.is_none());
+            }
+            other => panic!("expected Service command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_rejects_service_subcommand_without_action() {
+        let result = Cli::try_parse_from(["wakezilla", "service"]);
+        assert!(result.is_err(), "service requires an action argument");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use std::net::{IpAddr, Ipv4Addr};
-use tracing::{error, info, instrument, warn};
+use tracing::{error, info, instrument};
 
 mod api_models;
 mod client_server;
@@ -17,6 +17,7 @@ mod web;
 mod wol;
 
 pub use api_models::*;
+use setup::SetupArgs;
 
 /// Simple Wake-on-LAN sender + post-WOL reachability check.
 #[derive(Parser, Debug)]
@@ -36,6 +37,8 @@ pub enum Commands {
     ClientServer(ClientServerArgs),
     /// Start the terminal UI against a running proxy server
     Tui(TuiArgs),
+    /// Configure this host to auto-start a Wakezilla server as a system service
+    Setup(SetupArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -150,6 +153,12 @@ async fn main() -> Result<()> {
                 std::process::exit(1);
             }
         }
+        Commands::Setup(args) => {
+            if let Err(e) = setup::run(args) {
+                error!("Setup error: {}", e);
+                std::process::exit(1);
+            }
+        }
     }
 
     Ok(())
@@ -166,13 +175,7 @@ fn init_tracing() {
 }
 
 fn load_config() -> config::Config {
-    config::Config::from_env().unwrap_or_else(|e| {
-        warn!(
-            "Failed to load configuration from environment: {} - using defaults",
-            e
-        );
-        Default::default()
-    })
+    config::Config::load()
 }
 
 fn log_config(config: &config::Config) {
@@ -205,6 +208,32 @@ mod cli_tests {
         match cli.command {
             Commands::Tui(args) => assert_eq!(args.api_url, "http://192.168.1.200:3000"),
             other => panic!("expected Tui command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_setup_subcommand_with_flags() {
+        let cli = Cli::try_parse_from(["wakezilla", "setup", "--mode", "proxy", "--port", "3000"])
+            .expect("setup subcommand parses");
+
+        match cli.command {
+            Commands::Setup(args) => {
+                assert_eq!(args.mode.as_deref(), Some("proxy"));
+                assert_eq!(args.port, Some(3000));
+            }
+            other => panic!("expected Setup command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_setup_subcommand_without_flags() {
+        let cli = Cli::try_parse_from(["wakezilla", "setup"]).expect("bare setup parses");
+        match cli.command {
+            Commands::Setup(args) => {
+                assert!(args.mode.is_none());
+                assert!(args.port.is_none());
+            }
+            other => panic!("expected Setup command, got {other:?}"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,59 +185,6 @@ fn log_config(config: &config::Config) {
     );
 }
 
-#[cfg(test)]
-mod cli_tests {
-    use super::*;
-
-    #[test]
-    fn cli_accepts_tui_subcommand_with_default_api_url() {
-        let cli = Cli::try_parse_from(["wakezilla", "tui"]).expect("tui subcommand parses");
-
-        match cli.command {
-            Commands::Tui(args) => assert_eq!(args.api_url, "http://127.0.0.1:3000"),
-            other => panic!("expected Tui command, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn cli_accepts_tui_api_url_override() {
-        let cli =
-            Cli::try_parse_from(["wakezilla", "tui", "--api-url", "http://192.168.1.200:3000"])
-                .expect("tui subcommand parses with api override");
-
-        match cli.command {
-            Commands::Tui(args) => assert_eq!(args.api_url, "http://192.168.1.200:3000"),
-            other => panic!("expected Tui command, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn cli_accepts_setup_subcommand_with_flags() {
-        let cli = Cli::try_parse_from(["wakezilla", "setup", "--mode", "proxy", "--port", "3000"])
-            .expect("setup subcommand parses");
-
-        match cli.command {
-            Commands::Setup(args) => {
-                assert_eq!(args.mode.as_deref(), Some("proxy"));
-                assert_eq!(args.port, Some(3000));
-            }
-            other => panic!("expected Setup command, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn cli_accepts_setup_subcommand_without_flags() {
-        let cli = Cli::try_parse_from(["wakezilla", "setup"]).expect("bare setup parses");
-        match cli.command {
-            Commands::Setup(args) => {
-                assert!(args.mode.is_none());
-                assert!(args.port.is_none());
-            }
-            other => panic!("expected Setup command, got {other:?}"),
-        }
-    }
-}
-
 #[instrument(name = "handle_send_command", skip(args, config))]
 async fn handle_send_command(args: SendArgs, config: &config::Config) -> Result<()> {
     info!("Processing WOL send command");
@@ -288,5 +235,58 @@ async fn handle_send_command(args: SendArgs, config: &config::Config) -> Result<
             }
         }
         Err(_) => Err(anyhow::anyhow!("No runtime context available")),
+    }
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use super::*;
+
+    #[test]
+    fn cli_accepts_tui_subcommand_with_default_api_url() {
+        let cli = Cli::try_parse_from(["wakezilla", "tui"]).expect("tui subcommand parses");
+
+        match cli.command {
+            Commands::Tui(args) => assert_eq!(args.api_url, "http://127.0.0.1:3000"),
+            other => panic!("expected Tui command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_tui_api_url_override() {
+        let cli =
+            Cli::try_parse_from(["wakezilla", "tui", "--api-url", "http://192.168.1.200:3000"])
+                .expect("tui subcommand parses with api override");
+
+        match cli.command {
+            Commands::Tui(args) => assert_eq!(args.api_url, "http://192.168.1.200:3000"),
+            other => panic!("expected Tui command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_setup_subcommand_with_flags() {
+        let cli = Cli::try_parse_from(["wakezilla", "setup", "--mode", "proxy", "--port", "3000"])
+            .expect("setup subcommand parses");
+
+        match cli.command {
+            Commands::Setup(args) => {
+                assert_eq!(args.mode.as_deref(), Some("proxy"));
+                assert_eq!(args.port, Some(3000));
+            }
+            other => panic!("expected Setup command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_setup_subcommand_without_flags() {
+        let cli = Cli::try_parse_from(["wakezilla", "setup"]).expect("bare setup parses");
+        match cli.command {
+            Commands::Setup(args) => {
+                assert!(args.mode.is_none());
+                assert!(args.port.is_none());
+            }
+            other => panic!("expected Setup command, got {other:?}"),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod forward;
 mod proxy_server;
 mod scanner;
 mod service;
+mod setup;
 mod system;
 mod tui;
 mod web;

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -647,6 +647,9 @@ mod tests {
     }
 
     #[tokio::test]
+    // ENV_LOCK serializes mutation of process env vars across these tests; it must be held
+    // across the awaited handler call, so the sync guard intentionally spans the await point.
+    #[allow(clippy::await_holding_lock)]
     async fn add_machine_api_persists_new_entry() {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp_dir = tempdir().expect("failed to create temp dir");
@@ -775,6 +778,9 @@ mod tests {
     }
 
     #[tokio::test]
+    // ENV_LOCK serializes mutation of process env vars across these tests; it must be held
+    // across the awaited handler call, so the sync guard intentionally spans the await point.
+    #[allow(clippy::await_holding_lock)]
     async fn update_machine_api_applies_changes() {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp_dir = tempdir().expect("failed to create temp dir");
@@ -814,6 +820,9 @@ mod tests {
     }
 
     #[tokio::test]
+    // ENV_LOCK serializes mutation of process env vars across these tests; it must be held
+    // across the awaited handler call, so the sync guard intentionally spans the await point.
+    #[allow(clippy::await_holding_lock)]
     async fn delete_machine_api_stops_proxy_and_removes_machine() {
         let _lock = ENV_LOCK.lock().unwrap();
         let tmp_dir = tempdir().expect("failed to create temp dir");

--- a/src/service.rs
+++ b/src/service.rs
@@ -159,6 +159,9 @@ pub fn is_elevated() -> bool {
 }
 
 /// Install, enable, and start the system service for `mode`.
+///
+/// Idempotent: re-running over an existing install overwrites the unit/plist and
+/// reloads/recreates the service so a changed mode or port takes effect.
 /// `exe` is the absolute path to the wakezilla binary.
 pub fn install(mode: Mode, exe: &str) -> Result<()> {
     #[cfg(target_os = "linux")]
@@ -167,7 +170,10 @@ pub fn install(mode: Mode, exe: &str) -> Result<()> {
         let path = format!("/etc/systemd/system/{}.service", mode.service_name());
         std::fs::write(&path, unit).with_context(|| format!("writing {path}"))?;
         run("systemctl", &["daemon-reload"])?;
-        run("systemctl", &["enable", "--now", mode.service_name()])?;
+        run("systemctl", &["enable", mode.service_name()])?;
+        // restart (not `enable --now`) so an already-running service picks up the
+        // updated unit; restart also starts it if it was stopped.
+        run("systemctl", &["restart", mode.service_name()])?;
         Ok(())
     }
     #[cfg(target_os = "macos")]
@@ -175,11 +181,18 @@ pub fn install(mode: Mode, exe: &str) -> Result<()> {
         let plist = generate_launchd_plist(mode, exe);
         let path = format!("/Library/LaunchDaemons/{}.plist", mode.launchd_label());
         std::fs::write(&path, plist).with_context(|| format!("writing {path}"))?;
+        // Unload any previous instance (ignored if not loaded) so the updated
+        // plist is reloaded on a re-run instead of erroring "already loaded".
+        run_ignore_err("launchctl", &["unload", &path]);
         run("launchctl", &["load", "-w", &path])?;
         Ok(())
     }
     #[cfg(target_os = "windows")]
     {
+        // Best-effort teardown of any previous instance so `sc create` does not
+        // error "service already exists" on a re-run.
+        run_ignore_err("sc", &["stop", mode.service_name()]);
+        run_ignore_err("sc", &["delete", mode.service_name()]);
         let bin_path = format!("\"{exe}\" {}", mode.subcommand());
         run(
             "sc",
@@ -213,4 +226,11 @@ fn run(cmd: &str, args: &[&str]) -> Result<()> {
         return Err(anyhow!("{cmd} {args:?} exited with {status}"));
     }
     Ok(())
+}
+
+/// Run a command, ignoring its outcome. Used for best-effort teardown of a prior
+/// install (e.g. unloading/deleting an existing service) before reinstalling.
+#[allow(dead_code)]
+fn run_ignore_err(cmd: &str, args: &[&str]) {
+    let _ = Command::new(cmd).args(args).status();
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,5 +1,9 @@
 //! OS-native system service installation for the `setup` subcommand.
 
+use anyhow::{anyhow, Context, Result};
+use std::net::TcpStream;
+use std::time::Duration;
+
 /// Which Wakezilla server the service runs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
@@ -96,4 +100,28 @@ pub fn generate_launchd_plist(mode: Mode, exe: &str) -> String {
         exe = exe,
         sub = mode.subcommand(),
     )
+}
+
+/// Validate the service is up by TCP-connecting to `127.0.0.1:port`.
+/// Retries up to `attempts` times with a 500ms pause and per-attempt 1s timeout.
+pub fn validate(port: u16, attempts: u32) -> Result<()> {
+    let addr = format!("127.0.0.1:{port}");
+    let socket = addr
+        .parse()
+        .with_context(|| format!("invalid validation address {addr}"))?;
+
+    for attempt in 1..=attempts {
+        match TcpStream::connect_timeout(&socket, Duration::from_secs(1)) {
+            Ok(_) => return Ok(()),
+            Err(_) if attempt < attempts => {
+                std::thread::sleep(Duration::from_millis(500));
+            }
+            Err(e) => {
+                return Err(anyhow!(
+                    "service did not accept connections on {addr} after {attempts} attempts: {e}"
+                ));
+            }
+        }
+    }
+    Err(anyhow!("service not reachable on {addr}"))
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -83,6 +83,19 @@ pub fn generate_systemd_unit(mode: Mode, exe: &str) -> String {
     )
 }
 
+/// Directory where the macOS LaunchDaemon writes its stdout/stderr logs.
+pub const MACOS_LOG_DIR: &str = "/Library/Logs/wakezilla";
+
+/// Path the daemon's stdout is redirected to (macOS).
+fn macos_stdout_log(mode: Mode) -> String {
+    format!("{MACOS_LOG_DIR}/{}.out.log", mode.launchd_label())
+}
+
+/// Path the daemon's stderr is redirected to (macOS). Tracing logs go here.
+fn macos_stderr_log(mode: Mode) -> String {
+    format!("{MACOS_LOG_DIR}/{}.err.log", mode.launchd_label())
+}
+
 /// Render a launchd LaunchDaemon plist.
 // Platform-conditional: used by the systemd (Linux) / launchd (macOS) / Windows install paths; some are cfg'd out per-OS.
 #[allow(dead_code)]
@@ -103,11 +116,17 @@ pub fn generate_launchd_plist(mode: Mode, exe: &str) -> String {
          \t<true/>\n\
          \t<key>KeepAlive</key>\n\
          \t<true/>\n\
+         \t<key>StandardOutPath</key>\n\
+         \t<string>{out}</string>\n\
+         \t<key>StandardErrorPath</key>\n\
+         \t<string>{err}</string>\n\
          </dict>\n\
          </plist>\n",
         label = mode.launchd_label(),
         exe = exe,
         sub = mode.subcommand(),
+        out = macos_stdout_log(mode),
+        err = macos_stderr_log(mode),
     )
 }
 
@@ -178,6 +197,9 @@ pub fn install(mode: Mode, exe: &str) -> Result<()> {
     }
     #[cfg(target_os = "macos")]
     {
+        // Ensure the log directory exists so launchd can redirect stdout/stderr.
+        std::fs::create_dir_all(MACOS_LOG_DIR)
+            .with_context(|| format!("creating log dir {MACOS_LOG_DIR}"))?;
         let plist = generate_launchd_plist(mode, exe);
         let path = format!("/Library/LaunchDaemons/{}.plist", mode.launchd_label());
         std::fs::write(&path, plist).with_context(|| format!("writing {path}"))?;
@@ -233,6 +255,18 @@ fn run(cmd: &str, args: &[&str]) -> Result<()> {
 #[allow(dead_code)]
 fn run_ignore_err(cmd: &str, args: &[&str]) {
     let _ = Command::new(cmd).args(args).status();
+}
+
+/// Run a command inheriting the terminal's stdio (for streaming logs). Returns an
+/// error only if the command could not be spawned; a non-zero exit (e.g. Ctrl-C
+/// out of a `tail -f` / `journalctl -f`) is treated as a normal end of streaming.
+#[allow(dead_code)]
+fn run_inherit(cmd: &str, args: &[&str]) -> Result<()> {
+    Command::new(cmd)
+        .args(args)
+        .status()
+        .with_context(|| format!("failed to run {cmd}"))?;
+    Ok(())
 }
 
 /// Path to the on-disk service descriptor (systemd unit / launchd plist).
@@ -337,5 +371,87 @@ pub fn restart(mode: Mode) -> Result<()> {
     {
         let _ = mode;
         Err(anyhow!("service control not supported on this OS"))
+    }
+}
+
+/// Whether the service for `mode` is currently running.
+pub fn is_running(mode: Mode) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        Command::new("systemctl")
+            .args(["is-active", "--quiet", mode.service_name()])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let label = format!("system/{}", mode.launchd_label());
+        Command::new("launchctl")
+            .args(["print", &label])
+            .output()
+            .map(|o| {
+                o.status.success() && String::from_utf8_lossy(&o.stdout).contains("state = running")
+            })
+            .unwrap_or(false)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("sc")
+            .args(["query", mode.service_name()])
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).contains("RUNNING"))
+            .unwrap_or(false)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = mode;
+        false
+    }
+}
+
+/// Stream the service's logs to the terminal. `lines` is the tail length;
+/// `follow` keeps streaming new output until interrupted.
+pub fn logs(mode: Mode, follow: bool, lines: u32) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        let n = lines.to_string();
+        let mut args = vec!["-u", mode.service_name(), "-n", &n];
+        if follow {
+            args.push("-f");
+        }
+        run_inherit("journalctl", &args)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let path = macos_stderr_log(mode);
+        if !std::path::Path::new(&path).exists() {
+            anyhow::bail!(
+                "no log file at {path}. Re-run `sudo wakezilla setup` to enable log capture \
+                 (existing installs predate stdout/stderr redirection)."
+            );
+        }
+        let n = lines.to_string();
+        let mut args = vec!["-n", &n];
+        if follow {
+            args.push("-f");
+        }
+        args.push(&path);
+        run_inherit("tail", &args)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = (follow, lines);
+        println!(
+            "Log streaming is not captured for the Windows service ({}). \
+             Check the Windows Event Viewer.",
+            mode.subcommand()
+        );
+        Ok(())
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = (mode, follow, lines);
+        Err(anyhow!("log viewing not supported on this OS"))
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -427,8 +427,8 @@ pub fn logs(mode: Mode, follow: bool, lines: u32) -> Result<()> {
         let path = macos_stderr_log(mode);
         if !std::path::Path::new(&path).exists() {
             anyhow::bail!(
-                "no log file at {path}. Re-run `sudo wakezilla setup` to enable log capture \
-                 (existing installs predate stdout/stderr redirection)."
+                "no log file at {path} yet. The service may not have started or \
+                 produced any output."
             );
         }
         let n = lines.to_string();

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,99 @@
+//! OS-native system service installation for the `setup` subcommand.
+
+/// Which Wakezilla server the service runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Proxy,
+    Client,
+}
+
+impl Mode {
+    /// Parse from a CLI string. Returns `None` for unknown values.
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "proxy" | "proxy-server" => Some(Mode::Proxy),
+            "client" | "client-server" => Some(Mode::Client),
+            _ => None,
+        }
+    }
+
+    /// The wakezilla subcommand this mode launches.
+    pub fn subcommand(self) -> &'static str {
+        match self {
+            Mode::Proxy => "proxy-server",
+            Mode::Client => "client-server",
+        }
+    }
+
+    /// systemd unit / Windows service name.
+    pub fn service_name(self) -> &'static str {
+        match self {
+            Mode::Proxy => "wakezilla-proxy",
+            Mode::Client => "wakezilla-client",
+        }
+    }
+
+    /// launchd label (reverse-DNS).
+    pub fn launchd_label(self) -> &'static str {
+        match self {
+            Mode::Proxy => "dev.wakezilla.proxy",
+            Mode::Client => "dev.wakezilla.client",
+        }
+    }
+
+    /// Default port for this mode.
+    pub fn default_port(self) -> u16 {
+        match self {
+            Mode::Proxy => 3000,
+            Mode::Client => 3001,
+        }
+    }
+}
+
+/// Render a systemd unit file. `exe` is the absolute path to the wakezilla binary.
+pub fn generate_systemd_unit(mode: Mode, exe: &str) -> String {
+    format!(
+        "[Unit]\n\
+         Description=Wakezilla {desc}\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         ExecStart={exe} {sub}\n\
+         Restart=on-failure\n\
+         RestartSec=5\n\
+         \n\
+         [Install]\n\
+         WantedBy=multi-user.target\n",
+        desc = mode.subcommand(),
+        exe = exe,
+        sub = mode.subcommand(),
+    )
+}
+
+/// Render a launchd LaunchDaemon plist.
+pub fn generate_launchd_plist(mode: Mode, exe: &str) -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+         <plist version=\"1.0\">\n\
+         <dict>\n\
+         \t<key>Label</key>\n\
+         \t<string>{label}</string>\n\
+         \t<key>ProgramArguments</key>\n\
+         \t<array>\n\
+         \t\t<string>{exe}</string>\n\
+         \t\t<string>{sub}</string>\n\
+         \t</array>\n\
+         \t<key>RunAtLoad</key>\n\
+         \t<true/>\n\
+         \t<key>KeepAlive</key>\n\
+         \t<true/>\n\
+         </dict>\n\
+         </plist>\n",
+        label = mode.launchd_label(),
+        exe = exe,
+        sub = mode.subcommand(),
+    )
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use std::net::TcpStream;
+use std::process::Command;
 use std::time::Duration;
 
 /// Which Wakezilla server the service runs.
@@ -124,4 +125,83 @@ pub fn validate(port: u16, attempts: u32) -> Result<()> {
         }
     }
     Err(anyhow!("service not reachable on {addr}"))
+}
+
+/// Returns true if the current process can install a system service.
+pub fn is_elevated() -> bool {
+    #[cfg(unix)]
+    {
+        Command::new("id")
+            .arg("-u")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim() == "0")
+            .unwrap_or(false)
+    }
+    #[cfg(windows)]
+    {
+        // `net session` requires admin; non-zero exit if unprivileged.
+        Command::new("net")
+            .arg("session")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+}
+
+/// Install, enable, and start the system service for `mode`.
+/// `exe` is the absolute path to the wakezilla binary.
+pub fn install(mode: Mode, exe: &str) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        let unit = generate_systemd_unit(mode, exe);
+        let path = format!("/etc/systemd/system/{}.service", mode.service_name());
+        std::fs::write(&path, unit).with_context(|| format!("writing {path}"))?;
+        run("systemctl", &["daemon-reload"])?;
+        run("systemctl", &["enable", "--now", mode.service_name()])?;
+        Ok(())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let plist = generate_launchd_plist(mode, exe);
+        let path = format!("/Library/LaunchDaemons/{}.plist", mode.launchd_label());
+        std::fs::write(&path, plist).with_context(|| format!("writing {path}"))?;
+        run("launchctl", &["load", "-w", &path])?;
+        Ok(())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let bin_path = format!("\"{exe}\" {}", mode.subcommand());
+        run(
+            "sc",
+            &[
+                "create",
+                mode.service_name(),
+                &format!("binPath= {bin_path}"),
+                "start=",
+                "auto",
+            ],
+        )?;
+        run("sc", &["start", mode.service_name()])?;
+        Ok(())
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = (mode, exe);
+        Err(anyhow!("service install not supported on this OS"))
+    }
+}
+
+/// Run a command, returning an error if it exits non-zero.
+#[allow(dead_code)]
+fn run(cmd: &str, args: &[&str]) -> Result<()> {
+    let status = Command::new(cmd)
+        .args(args)
+        .status()
+        .with_context(|| format!("failed to run {cmd}"))?;
+    if !status.success() {
+        return Err(anyhow!("{cmd} {args:?} exited with {status}"));
+    }
+    Ok(())
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -234,3 +234,108 @@ fn run(cmd: &str, args: &[&str]) -> Result<()> {
 fn run_ignore_err(cmd: &str, args: &[&str]) {
     let _ = Command::new(cmd).args(args).status();
 }
+
+/// Path to the on-disk service descriptor (systemd unit / launchd plist).
+/// Not defined on Windows, which has no descriptor file (services live in the SCM).
+#[cfg(target_os = "macos")]
+fn descriptor_path(mode: Mode) -> String {
+    format!("/Library/LaunchDaemons/{}.plist", mode.launchd_label())
+}
+#[cfg(target_os = "linux")]
+fn descriptor_path(mode: Mode) -> String {
+    format!("/etc/systemd/system/{}.service", mode.service_name())
+}
+
+/// True if the service for `mode` appears installed on this host.
+pub fn is_installed(mode: Mode) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        std::path::Path::new(&descriptor_path(mode)).exists()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("sc")
+            .args(["query", mode.service_name()])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = mode;
+        false
+    }
+}
+
+/// The set of modes currently installed as services on this host.
+pub fn installed_modes() -> Vec<Mode> {
+    [Mode::Proxy, Mode::Client]
+        .into_iter()
+        .filter(|m| is_installed(*m))
+        .collect()
+}
+
+/// Start the installed service for `mode`.
+pub fn start(mode: Mode) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        run("systemctl", &["start", mode.service_name()])
+    }
+    #[cfg(target_os = "macos")]
+    {
+        run("launchctl", &["load", "-w", &descriptor_path(mode)])
+    }
+    #[cfg(target_os = "windows")]
+    {
+        run("sc", &["start", mode.service_name()])
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = mode;
+        Err(anyhow!("service control not supported on this OS"))
+    }
+}
+
+/// Stop the installed service for `mode`.
+pub fn stop(mode: Mode) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        run("systemctl", &["stop", mode.service_name()])
+    }
+    #[cfg(target_os = "macos")]
+    {
+        run("launchctl", &["unload", &descriptor_path(mode)])
+    }
+    #[cfg(target_os = "windows")]
+    {
+        run("sc", &["stop", mode.service_name()])
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = mode;
+        Err(anyhow!("service control not supported on this OS"))
+    }
+}
+
+/// Restart the installed service for `mode`.
+pub fn restart(mode: Mode) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        run("systemctl", &["restart", mode.service_name()])
+    }
+    #[cfg(target_os = "macos")]
+    {
+        run_ignore_err("launchctl", &["unload", &descriptor_path(mode)]);
+        run("launchctl", &["load", "-w", &descriptor_path(mode)])
+    }
+    #[cfg(target_os = "windows")]
+    {
+        run_ignore_err("sc", &["stop", mode.service_name()]);
+        run("sc", &["start", mode.service_name()])
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = mode;
+        Err(anyhow!("service control not supported on this OS"))
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -178,7 +178,8 @@ pub fn install(mode: Mode, exe: &str) -> Result<()> {
             &[
                 "create",
                 mode.service_name(),
-                &format!("binPath= {bin_path}"),
+                "binPath=",
+                &bin_path,
                 "start=",
                 "auto",
             ],

--- a/src/service.rs
+++ b/src/service.rs
@@ -31,6 +31,8 @@ impl Mode {
     }
 
     /// systemd unit / Windows service name.
+    // Platform-conditional: used by the systemd (Linux) / launchd (macOS) / Windows install paths; some are cfg'd out per-OS.
+    #[allow(dead_code)]
     pub fn service_name(self) -> &'static str {
         match self {
             Mode::Proxy => "wakezilla-proxy",
@@ -39,6 +41,8 @@ impl Mode {
     }
 
     /// launchd label (reverse-DNS).
+    // Platform-conditional: used by the systemd (Linux) / launchd (macOS) / Windows install paths; some are cfg'd out per-OS.
+    #[allow(dead_code)]
     pub fn launchd_label(self) -> &'static str {
         match self {
             Mode::Proxy => "dev.wakezilla.proxy",
@@ -56,6 +60,8 @@ impl Mode {
 }
 
 /// Render a systemd unit file. `exe` is the absolute path to the wakezilla binary.
+// Platform-conditional: used by the systemd (Linux) / launchd (macOS) / Windows install paths; some are cfg'd out per-OS.
+#[allow(dead_code)]
 pub fn generate_systemd_unit(mode: Mode, exe: &str) -> String {
     format!(
         "[Unit]\n\
@@ -78,6 +84,8 @@ pub fn generate_systemd_unit(mode: Mode, exe: &str) -> String {
 }
 
 /// Render a launchd LaunchDaemon plist.
+// Platform-conditional: used by the systemd (Linux) / launchd (macOS) / Windows install paths; some are cfg'd out per-OS.
+#[allow(dead_code)]
 pub fn generate_launchd_plist(mode: Mode, exe: &str) -> String {
     format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,0 +1,47 @@
+//! Interactive `setup` wizard: configure and install a Wakezilla system service.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::config::{self, Config};
+use crate::service::{self, Mode};
+
+/// CLI arguments for the `setup` subcommand.
+#[derive(Parser, Debug, Default)]
+#[command()]
+pub struct SetupArgs {
+    /// Pre-select the mode ("proxy" or "client"); skips the TUI prompt if combined with --port.
+    #[arg(long, help_heading = "Setup Options")]
+    pub mode: Option<String>,
+
+    /// Pre-select the port; skips the TUI prompt if combined with --mode.
+    #[arg(long, help_heading = "Setup Options")]
+    pub port: Option<u16>,
+}
+
+/// Build a Config with the chosen port placed in the correct field for `mode`.
+pub fn build_config(mode: Mode, port: u16) -> Config {
+    let mut cfg = Config::default();
+    match mode {
+        Mode::Proxy => cfg.server.proxy_port = port,
+        Mode::Client => cfg.server.client_port = port,
+    }
+    cfg
+}
+
+/// Write the config file, install the service, and validate it.
+/// Returns the config path on success.
+pub fn apply(mode: Mode, port: u16) -> Result<std::path::PathBuf> {
+    let exe = std::env::current_exe().context("failed to resolve current executable path")?;
+    let exe = exe.to_string_lossy().to_string();
+
+    let cfg = build_config(mode, port);
+    let path = config::config_path();
+    cfg.save_to(&path)
+        .with_context(|| format!("failed to write config to {}", path.display()))?;
+
+    service::install(mode, &exe).context("failed to install system service")?;
+    service::validate(port, 10).context("service installed but did not become reachable")?;
+
+    Ok(path)
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -228,13 +228,18 @@ fn draw_wizard(f: &mut Frame, w: &Wizard) {
             let proxy = mode_span("Proxy server", w.mode == Mode::Proxy);
             let client = mode_span("Client server", w.mode == Mode::Client);
             vec![
-                Line::from("What do you want to configure? (Left/Right to switch, Enter to confirm)"),
+                Line::from(
+                    "What do you want to configure? (Left/Right to switch, Enter to confirm)",
+                ),
                 Line::from(""),
                 Line::from(vec![proxy, Span::raw("   "), client]),
             ]
         }
         Step::PortInput => vec![
-            Line::from(format!("Port for {} (Enter to confirm):", w.mode.subcommand())),
+            Line::from(format!(
+                "Port for {} (Enter to confirm):",
+                w.mode.subcommand()
+            )),
             Line::from(""),
             Line::from(Span::styled(
                 format!("> {}", w.port_input),
@@ -262,8 +267,8 @@ fn draw_wizard(f: &mut Frame, w: &Wizard) {
     let para = Paragraph::new(lines).block(Block::default().borders(Borders::ALL));
     f.render_widget(para, chunks[1]);
 
-    let footer = Paragraph::new("Esc / Ctrl-C: cancel")
-        .block(Block::default().borders(Borders::ALL));
+    let footer =
+        Paragraph::new("Esc / Ctrl-C: cancel").block(Block::default().borders(Borders::ALL));
     f.render_widget(footer, chunks[2]);
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -45,3 +45,238 @@ pub fn apply(mode: Mode, port: u16) -> Result<std::path::PathBuf> {
 
     Ok(path)
 }
+
+use std::io;
+use std::time::Duration;
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    Frame, Terminal,
+};
+
+/// Wizard entry point. Requires elevation. Falls back to the TUI when the mode/port
+/// are not both provided on the command line.
+pub fn run(args: SetupArgs) -> Result<()> {
+    if !service::is_elevated() {
+        eprintln!(
+            "wakezilla setup must run with administrator privileges.\n\
+             Re-run with: sudo wakezilla setup   (Linux/macOS)  or  an elevated shell (Windows)."
+        );
+        std::process::exit(1);
+    }
+
+    // Headless path: both flags provided.
+    if let (Some(mode_str), Some(port)) = (&args.mode, args.port) {
+        let mode = Mode::from_str_opt(mode_str)
+            .with_context(|| format!("invalid --mode '{mode_str}' (use 'proxy' or 'client')"))?;
+        let path = apply(mode, port)?;
+        println!(
+            "Configured {} on port {port}. Config written to {}.",
+            mode.subcommand(),
+            path.display()
+        );
+        return Ok(());
+    }
+
+    let (mode, port) = run_wizard(args)?;
+    let path = apply(mode, port)?;
+    println!(
+        "Configured {} on port {port}. Config written to {}.",
+        mode.subcommand(),
+        path.display()
+    );
+    Ok(())
+}
+
+#[derive(PartialEq)]
+enum Step {
+    ModeSelect,
+    PortInput,
+    Confirm,
+}
+
+struct Wizard {
+    step: Step,
+    mode: Mode,
+    port_input: String,
+    error: Option<String>,
+}
+
+impl Wizard {
+    fn new(args: &SetupArgs) -> Self {
+        let mode = args
+            .mode
+            .as_deref()
+            .and_then(Mode::from_str_opt)
+            .unwrap_or(Mode::Proxy);
+        Wizard {
+            step: Step::ModeSelect,
+            mode,
+            port_input: args
+                .port
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| mode.default_port().to_string()),
+            error: None,
+        }
+    }
+}
+
+/// Run the interactive wizard, returning the chosen (mode, port).
+fn run_wizard(args: SetupArgs) -> Result<(Mode, u16)> {
+    enable_raw_mode().context("failed to enable raw mode")?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen).context("failed to enter alt screen")?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("failed to create terminal")?;
+
+    let result = wizard_loop(&mut terminal, args);
+
+    disable_raw_mode().ok();
+    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+    terminal.show_cursor().ok();
+
+    result
+}
+
+fn wizard_loop<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    args: SetupArgs,
+) -> Result<(Mode, u16)> {
+    let mut w = Wizard::new(&args);
+
+    loop {
+        terminal.draw(|f| draw_wizard(f, &w))?;
+
+        if !event::poll(Duration::from_millis(200))? {
+            continue;
+        }
+        if let Event::Key(key) = event::read()? {
+            // Ctrl-C / Esc aborts.
+            if key.code == KeyCode::Esc
+                || (key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL))
+            {
+                return Err(anyhow::anyhow!("setup cancelled"));
+            }
+
+            match w.step {
+                Step::ModeSelect => match key.code {
+                    KeyCode::Left | KeyCode::Right | KeyCode::Char('h') | KeyCode::Char('l') => {
+                        w.mode = match w.mode {
+                            Mode::Proxy => Mode::Client,
+                            Mode::Client => Mode::Proxy,
+                        };
+                        w.port_input = w.mode.default_port().to_string();
+                    }
+                    KeyCode::Enter => w.step = Step::PortInput,
+                    _ => {}
+                },
+                Step::PortInput => match key.code {
+                    KeyCode::Char(c) if c.is_ascii_digit() && w.port_input.len() < 5 => {
+                        w.port_input.push(c);
+                    }
+                    KeyCode::Backspace => {
+                        w.port_input.pop();
+                    }
+                    KeyCode::Enter => match w.port_input.parse::<u16>() {
+                        Ok(p) if p > 0 => {
+                            w.error = None;
+                            w.step = Step::Confirm;
+                        }
+                        _ => w.error = Some("Enter a valid port (1-65535)".to_string()),
+                    },
+                    _ => {}
+                },
+                Step::Confirm => match key.code {
+                    KeyCode::Enter => {
+                        let port: u16 = w.port_input.parse().unwrap_or(w.mode.default_port());
+                        return Ok((w.mode, port));
+                    }
+                    KeyCode::Char('b') => w.step = Step::PortInput,
+                    _ => {}
+                },
+            }
+        }
+    }
+}
+
+fn draw_wizard(f: &mut Frame, w: &Wizard) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(6),
+            Constraint::Length(3),
+        ])
+        .split(f.area());
+
+    let title = Paragraph::new("Wakezilla Setup")
+        .style(Style::default().add_modifier(Modifier::BOLD))
+        .block(Block::default().borders(Borders::ALL));
+    f.render_widget(title, chunks[0]);
+
+    let body = match w.step {
+        Step::ModeSelect => {
+            let proxy = mode_span("Proxy server", w.mode == Mode::Proxy);
+            let client = mode_span("Client server", w.mode == Mode::Client);
+            vec![
+                Line::from("What do you want to configure? (Left/Right to switch, Enter to confirm)"),
+                Line::from(""),
+                Line::from(vec![proxy, Span::raw("   "), client]),
+            ]
+        }
+        Step::PortInput => vec![
+            Line::from(format!("Port for {} (Enter to confirm):", w.mode.subcommand())),
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("> {}", w.port_input),
+                Style::default().add_modifier(Modifier::BOLD),
+            )),
+        ],
+        Step::Confirm => vec![
+            Line::from("Confirm configuration (Enter to apply, 'b' to go back):"),
+            Line::from(""),
+            Line::from(format!("  Mode: {}", w.mode.subcommand())),
+            Line::from(format!("  Port: {}", w.port_input)),
+            Line::from(format!("  Config: {}", config::config_path().display())),
+        ],
+    };
+
+    let mut lines = body;
+    if let Some(err) = &w.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            err.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+    }
+
+    let para = Paragraph::new(lines).block(Block::default().borders(Borders::ALL));
+    f.render_widget(para, chunks[1]);
+
+    let footer = Paragraph::new("Esc / Ctrl-C: cancel")
+        .block(Block::default().borders(Borders::ALL));
+    f.render_widget(footer, chunks[2]);
+}
+
+fn mode_span(label: &str, selected: bool) -> Span<'static> {
+    let text = if selected {
+        format!("[ {label} ]")
+    } else {
+        format!("  {label}  ")
+    };
+    let style = if selected {
+        Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    Span::styled(text, style)
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -29,6 +29,10 @@ pub enum ServiceAction {
     Start,
     Stop,
     Restart,
+    /// Report whether the service is running.
+    Status,
+    /// Show the service's logs (prints status first).
+    Logs,
 }
 
 /// CLI arguments for the `service` subcommand.
@@ -42,6 +46,14 @@ pub struct ServiceArgs {
     /// Target server ("proxy" or "client"); skips the TUI prompt.
     #[arg(long, help_heading = "Service Options")]
     pub mode: Option<String>,
+
+    /// For `logs`: keep streaming new output until interrupted.
+    #[arg(long, short = 'f', help_heading = "Service Options")]
+    pub follow: bool,
+
+    /// For `logs`: number of trailing lines to show (default 50).
+    #[arg(long, short = 'n', help_heading = "Service Options")]
+    pub lines: Option<u32>,
 }
 
 /// Build a Config with the chosen port placed in the correct field for `mode`.
@@ -385,9 +397,9 @@ fn mode_span(label: &str, selected: bool) -> Span<'static> {
     Span::styled(text, style)
 }
 
-/// Entry point for the `service` subcommand: start/stop/restart an installed service.
-/// Requires elevation. Resolves the target mode from `--mode`, a single install, or a
-/// TUI picker when both proxy and client are installed.
+/// Entry point for the `service` subcommand: start/stop/restart/status/logs of an
+/// installed service. Requires elevation. Resolves the target mode from `--mode`, a
+/// single install, or a TUI picker when both proxy and client are installed.
 pub fn run_service(args: ServiceArgs) -> Result<()> {
     if !service::is_elevated() {
         eprintln!(
@@ -423,18 +435,37 @@ pub fn run_service(args: ServiceArgs) -> Result<()> {
     };
 
     match args.action {
-        ServiceAction::Start => service::start(mode).context("failed to start service")?,
-        ServiceAction::Stop => service::stop(mode).context("failed to stop service")?,
-        ServiceAction::Restart => service::restart(mode).context("failed to restart service")?,
+        ServiceAction::Start => {
+            service::start(mode).context("failed to start service")?;
+            println!("{} service started.", mode.subcommand());
+        }
+        ServiceAction::Stop => {
+            service::stop(mode).context("failed to stop service")?;
+            println!("{} service stopped.", mode.subcommand());
+        }
+        ServiceAction::Restart => {
+            service::restart(mode).context("failed to restart service")?;
+            println!("{} service restarted.", mode.subcommand());
+        }
+        ServiceAction::Status => print_status(mode),
+        ServiceAction::Logs => {
+            print_status(mode);
+            println!("--- logs ---");
+            service::logs(mode, args.follow, args.lines.unwrap_or(50))
+                .context("failed to show logs")?;
+        }
     }
-
-    let verb = match args.action {
-        ServiceAction::Start => "started",
-        ServiceAction::Stop => "stopped",
-        ServiceAction::Restart => "restarted",
-    };
-    println!("{} service {verb}.", mode.subcommand());
     Ok(())
+}
+
+/// Print whether the service for `mode` is currently running.
+fn print_status(mode: Mode) {
+    let state = if service::is_running(mode) {
+        "running"
+    } else {
+        "stopped"
+    };
+    println!("{} service: {state}", mode.subcommand());
 }
 
 /// Interactive picker to choose one mode from the installed set (Left/Right, Enter).

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -17,6 +17,10 @@ pub struct SetupArgs {
     /// Pre-select the port; skips the TUI prompt if combined with --mode.
     #[arg(long, help_heading = "Setup Options")]
     pub port: Option<u16>,
+
+    /// Skip the overwrite confirmation prompt (for non-interactive use).
+    #[arg(long, short = 'y', help_heading = "Setup Options")]
+    pub yes: bool,
 }
 
 /// Action for the `service` subcommand.
@@ -52,12 +56,23 @@ pub fn build_config(mode: Mode, port: u16) -> Config {
 
 /// Write the config file, install the service, and validate it.
 /// Returns the config path on success.
+///
+/// If a config file already exists, its other settings (e.g. the other server's
+/// port) are preserved; only the target mode's port is updated.
 pub fn apply(mode: Mode, port: u16) -> Result<std::path::PathBuf> {
     let exe = std::env::current_exe().context("failed to resolve current executable path")?;
     let exe = exe.to_string_lossy().to_string();
 
-    let cfg = build_config(mode, port);
     let path = config::config_path();
+    let mut cfg = if path.exists() {
+        Config::load_from(&path).unwrap_or_else(|_| build_config(mode, port))
+    } else {
+        build_config(mode, port)
+    };
+    match mode {
+        Mode::Proxy => cfg.server.proxy_port = port,
+        Mode::Client => cfg.server.client_port = port,
+    }
     cfg.save_to(&path)
         .with_context(|| format!("failed to write config to {}", path.display()))?;
 
@@ -67,7 +82,60 @@ pub fn apply(mode: Mode, port: u16) -> Result<std::path::PathBuf> {
     Ok(path)
 }
 
+/// Summarize any existing Wakezilla configuration/services on this host.
+/// Returns `None` if nothing is installed and no config file exists.
+fn existing_summary() -> Option<String> {
+    let installed = service::installed_modes();
+    let path = config::config_path();
+    let cfg_exists = path.exists();
+    if installed.is_empty() && !cfg_exists {
+        return None;
+    }
+
+    let mut lines = Vec::new();
+    if cfg_exists {
+        if let Ok(cfg) = Config::load_from(&path) {
+            lines.push(format!(
+                "  config: {} (proxy_port={}, client_port={})",
+                path.display(),
+                cfg.server.proxy_port,
+                cfg.server.client_port
+            ));
+        } else {
+            lines.push(format!("  config: {}", path.display()));
+        }
+    }
+    if !installed.is_empty() {
+        let names: Vec<&str> = installed.iter().map(|m| m.subcommand()).collect();
+        lines.push(format!("  installed services: {}", names.join(", ")));
+    }
+    Some(lines.join("\n"))
+}
+
+/// Prompt the operator to confirm overwriting an existing configuration.
+/// Returns `Ok(true)` when there is nothing to overwrite or the user confirms.
+fn confirm_overwrite() -> Result<bool> {
+    let Some(summary) = existing_summary() else {
+        return Ok(true);
+    };
+
+    println!("An existing Wakezilla configuration was detected:");
+    println!("{summary}");
+    print!("Overwrite / reconfigure? [y/N]: ");
+    std::io::stdout().flush().ok();
+
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .context("failed to read confirmation")?;
+    Ok(matches!(
+        input.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
 use std::io;
+use std::io::Write;
 use std::time::Duration;
 
 use crossterm::{
@@ -95,10 +163,16 @@ pub fn run(args: SetupArgs) -> Result<()> {
         std::process::exit(1);
     }
 
+    let skip_confirm = args.yes;
+
     // Headless path: both flags provided.
     if let (Some(mode_str), Some(port)) = (&args.mode, args.port) {
         let mode = Mode::from_str_opt(mode_str)
             .with_context(|| format!("invalid --mode '{mode_str}' (use 'proxy' or 'client')"))?;
+        if !skip_confirm && !confirm_overwrite()? {
+            println!("Aborted; no changes made.");
+            return Ok(());
+        }
         let path = apply(mode, port)?;
         println!(
             "Configured {} on port {port}. Config written to {}.",
@@ -109,6 +183,10 @@ pub fn run(args: SetupArgs) -> Result<()> {
     }
 
     let (mode, port) = run_wizard(args)?;
+    if !skip_confirm && !confirm_overwrite()? {
+        println!("Aborted; no changes made.");
+        return Ok(());
+    }
     let path = apply(mode, port)?;
     println!(
         "Configured {} on port {port}. Config written to {}.",

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -19,6 +19,27 @@ pub struct SetupArgs {
     pub port: Option<u16>,
 }
 
+/// Action for the `service` subcommand.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ServiceAction {
+    Start,
+    Stop,
+    Restart,
+}
+
+/// CLI arguments for the `service` subcommand.
+#[derive(Parser, Debug)]
+#[command()]
+pub struct ServiceArgs {
+    /// Action to perform on the installed service.
+    #[arg(value_enum)]
+    pub action: ServiceAction,
+
+    /// Target server ("proxy" or "client"); skips the TUI prompt.
+    #[arg(long, help_heading = "Service Options")]
+    pub mode: Option<String>,
+}
+
 /// Build a Config with the chosen port placed in the correct field for `mode`.
 pub fn build_config(mode: Mode, port: u16) -> Config {
     let mut cfg = Config::default();
@@ -284,4 +305,142 @@ fn mode_span(label: &str, selected: bool) -> Span<'static> {
         Style::default()
     };
     Span::styled(text, style)
+}
+
+/// Entry point for the `service` subcommand: start/stop/restart an installed service.
+/// Requires elevation. Resolves the target mode from `--mode`, a single install, or a
+/// TUI picker when both proxy and client are installed.
+pub fn run_service(args: ServiceArgs) -> Result<()> {
+    if !service::is_elevated() {
+        eprintln!(
+            "wakezilla service must run with administrator privileges.\n\
+             Re-run with: sudo wakezilla service <action>   (Linux/macOS)  or  an elevated shell (Windows)."
+        );
+        std::process::exit(1);
+    }
+
+    let mode = match &args.mode {
+        Some(mode_str) => {
+            let mode = Mode::from_str_opt(mode_str).with_context(|| {
+                format!("invalid --mode '{mode_str}' (use 'proxy' or 'client')")
+            })?;
+            if !service::is_installed(mode) {
+                anyhow::bail!(
+                    "{} service is not installed. Run `wakezilla setup` first.",
+                    mode.subcommand()
+                );
+            }
+            mode
+        }
+        None => {
+            let installed = service::installed_modes();
+            match installed.as_slice() {
+                [] => {
+                    anyhow::bail!("No Wakezilla service is installed. Run `wakezilla setup` first.")
+                }
+                [only] => *only,
+                _ => pick_mode(&installed)?,
+            }
+        }
+    };
+
+    match args.action {
+        ServiceAction::Start => service::start(mode).context("failed to start service")?,
+        ServiceAction::Stop => service::stop(mode).context("failed to stop service")?,
+        ServiceAction::Restart => service::restart(mode).context("failed to restart service")?,
+    }
+
+    let verb = match args.action {
+        ServiceAction::Start => "started",
+        ServiceAction::Stop => "stopped",
+        ServiceAction::Restart => "restarted",
+    };
+    println!("{} service {verb}.", mode.subcommand());
+    Ok(())
+}
+
+/// Interactive picker to choose one mode from the installed set (Left/Right, Enter).
+fn pick_mode(modes: &[Mode]) -> Result<Mode> {
+    enable_raw_mode().context("failed to enable raw mode")?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen).context("failed to enter alt screen")?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("failed to create terminal")?;
+
+    let result = pick_mode_loop(&mut terminal, modes);
+
+    disable_raw_mode().ok();
+    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+    terminal.show_cursor().ok();
+
+    result
+}
+
+fn pick_mode_loop<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    modes: &[Mode],
+) -> Result<Mode> {
+    let mut selected = 0usize;
+
+    loop {
+        terminal.draw(|f| draw_pick_mode(f, modes, selected))?;
+
+        if !event::poll(Duration::from_millis(200))? {
+            continue;
+        }
+        if let Event::Key(key) = event::read()? {
+            if key.code == KeyCode::Esc
+                || (key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL))
+            {
+                return Err(anyhow::anyhow!("cancelled"));
+            }
+            match key.code {
+                KeyCode::Left | KeyCode::Right | KeyCode::Char('h') | KeyCode::Char('l') => {
+                    selected = (selected + 1) % modes.len();
+                }
+                KeyCode::Enter => return Ok(modes[selected]),
+                _ => {}
+            }
+        }
+    }
+}
+
+fn draw_pick_mode(f: &mut Frame, modes: &[Mode], selected: usize) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(4),
+            Constraint::Length(3),
+        ])
+        .split(f.area());
+
+    let title = Paragraph::new("Wakezilla Service")
+        .style(Style::default().add_modifier(Modifier::BOLD))
+        .block(Block::default().borders(Borders::ALL));
+    f.render_widget(title, chunks[0]);
+
+    let spans: Vec<Span> = modes
+        .iter()
+        .enumerate()
+        .flat_map(|(i, m)| {
+            let label = match m {
+                Mode::Proxy => "Proxy server",
+                Mode::Client => "Client server",
+            };
+            vec![mode_span(label, i == selected), Span::raw("   ")]
+        })
+        .collect();
+
+    let body = vec![
+        Line::from("Which service? (Left/Right to switch, Enter to select)"),
+        Line::from(""),
+        Line::from(spans),
+    ];
+    let para = Paragraph::new(body).block(Block::default().borders(Borders::ALL));
+    f.render_widget(para, chunks[1]);
+
+    let footer =
+        Paragraph::new("Esc / Ctrl-C: cancel").block(Block::default().borders(Borders::ALL));
+    f.render_widget(footer, chunks[2]);
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -78,6 +78,9 @@ fn helper_methods_return_expected_durations() {
 
 #[test]
 fn config_save_load_round_trip_preserves_ports() {
+    // `load_from` merges `WAKEZILLA__*` env vars, so hold the env lock to avoid
+    // interference from tests that set those vars concurrently.
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
 

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,18 +1,26 @@
+use std::sync::Mutex;
 use std::time::Duration;
 
 use wakezilla::config::Config;
 
+/// Serializes tests that read or mutate the process environment, since env vars
+/// are global to the process and tests run concurrently by default.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
 struct EnvGuard {
     keys: Vec<&'static str>,
+    _lock: std::sync::MutexGuard<'static, ()>,
 }
 
 impl EnvGuard {
     fn set(vars: &[(&'static str, &str)]) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         for (key, value) in vars {
             std::env::set_var(key, value);
         }
         Self {
             keys: vars.iter().map(|(key, _)| *key).collect(),
+            _lock: lock,
         }
     }
 }
@@ -66,4 +74,33 @@ fn helper_methods_return_expected_durations() {
     assert_eq!(cfg.network_read_timeout(), Duration::from_secs(2));
     assert_eq!(cfg.health_check_interval(), Duration::from_millis(30_000));
     assert_eq!(cfg.system_shutdown_sleep_duration(), Duration::from_secs(5));
+}
+
+#[test]
+fn config_save_load_round_trip_preserves_ports() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+
+    let mut cfg = Config::default();
+    cfg.server.proxy_port = 4567;
+    cfg.server.client_port = 7654;
+
+    cfg.save_to(&path).expect("save_to writes toml");
+    assert!(path.exists(), "config file should be written");
+
+    let loaded = Config::load_from(&path).expect("load_from reads toml");
+    assert_eq!(loaded.server.proxy_port, 4567);
+    assert_eq!(loaded.server.client_port, 7654);
+}
+
+#[test]
+fn config_load_from_missing_file_returns_defaults() {
+    // `load_from` merges `WAKEZILLA__*` env vars, so hold the env lock to avoid
+    // interference from tests that set those vars concurrently.
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("does-not-exist.toml");
+
+    let loaded = Config::load_from(&path).expect("missing file falls back to defaults");
+    assert_eq!(loaded.server.proxy_port, 3000);
 }

--- a/tests/setup_tests.rs
+++ b/tests/setup_tests.rs
@@ -1,0 +1,33 @@
+use wakezilla::service::{self, Mode};
+
+#[test]
+fn mode_parses_from_str() {
+    assert_eq!(Mode::from_str_opt("proxy"), Some(Mode::Proxy));
+    assert_eq!(Mode::from_str_opt("client"), Some(Mode::Client));
+    assert_eq!(Mode::from_str_opt("nonsense"), None);
+}
+
+#[test]
+fn mode_exposes_subcommand_and_service_name() {
+    assert_eq!(Mode::Proxy.subcommand(), "proxy-server");
+    assert_eq!(Mode::Client.subcommand(), "client-server");
+    assert_eq!(Mode::Proxy.service_name(), "wakezilla-proxy");
+    assert_eq!(Mode::Client.service_name(), "wakezilla-client");
+}
+
+#[test]
+fn systemd_unit_contains_exec_start_with_exe_and_subcommand() {
+    let unit = service::generate_systemd_unit(Mode::Proxy, "/usr/local/bin/wakezilla");
+    assert!(unit.contains("ExecStart=/usr/local/bin/wakezilla proxy-server"));
+    assert!(unit.contains("[Service]"));
+    assert!(unit.contains("WantedBy=multi-user.target"));
+}
+
+#[test]
+fn launchd_plist_contains_label_exe_and_subcommand() {
+    let plist = service::generate_launchd_plist(Mode::Client, "/usr/local/bin/wakezilla");
+    assert!(plist.contains("dev.wakezilla.client"));
+    assert!(plist.contains("/usr/local/bin/wakezilla"));
+    assert!(plist.contains("client-server"));
+    assert!(plist.contains("<key>RunAtLoad</key>"));
+}

--- a/tests/setup_tests.rs
+++ b/tests/setup_tests.rs
@@ -31,3 +31,23 @@ fn launchd_plist_contains_label_exe_and_subcommand() {
     assert!(plist.contains("client-server"));
     assert!(plist.contains("<key>RunAtLoad</key>"));
 }
+
+#[test]
+fn validate_succeeds_when_port_is_listening() {
+    use std::net::TcpListener;
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    // Listener stays alive for the duration of the test.
+    service::validate(port, 5).expect("validate connects to open port");
+}
+
+#[test]
+fn validate_fails_when_port_is_closed() {
+    // Bind then drop to obtain an almost-certainly-free port.
+    let port = {
+        let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        l.local_addr().unwrap().port()
+    };
+    let result = service::validate(port, 2);
+    assert!(result.is_err(), "validate should fail on closed port");
+}

--- a/tests/setup_tests.rs
+++ b/tests/setup_tests.rs
@@ -51,3 +51,14 @@ fn validate_fails_when_port_is_closed() {
     let result = service::validate(port, 2);
     assert!(result.is_err(), "validate should fail on closed port");
 }
+
+#[test]
+fn build_config_sets_correct_port_for_mode() {
+    let proxy = wakezilla::setup::build_config(Mode::Proxy, 5000);
+    assert_eq!(proxy.server.proxy_port, 5000);
+    assert_eq!(proxy.server.client_port, 3001); // untouched default
+
+    let client = wakezilla::setup::build_config(Mode::Client, 6000);
+    assert_eq!(client.server.client_port, 6000);
+    assert_eq!(client.server.proxy_port, 3000); // untouched default
+}

--- a/tests/setup_tests.rs
+++ b/tests/setup_tests.rs
@@ -30,6 +30,9 @@ fn launchd_plist_contains_label_exe_and_subcommand() {
     assert!(plist.contains("/usr/local/bin/wakezilla"));
     assert!(plist.contains("client-server"));
     assert!(plist.contains("<key>RunAtLoad</key>"));
+    assert!(plist.contains("<key>StandardErrorPath</key>"));
+    assert!(plist.contains("<key>StandardOutPath</key>"));
+    assert!(plist.contains("/Library/Logs/wakezilla/dev.wakezilla.client.err.log"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a `wakezilla setup` TUI subcommand to configure a host to auto-start the **proxy** or **client** server as a native system service, plus a `wakezilla service` subcommand to start/stop/restart it.

### `setup`
- Root-gated interactive ratatui wizard (or headless via `--mode`/`--port`).
- Writes an OS-standard TOML config file (`/etc/wakezilla`, `/Library/Application Support/wakezilla`, `%ProgramData%\wakezilla`).
- Installs + enables a native service:
  - **Linux**: systemd unit
  - **macOS**: launchd LaunchDaemon
  - **Windows**: Service Manager (`sc`)
- Validates the service is reachable (TCP probe) after install.
- **Idempotent**: re-running reloads/recreates the service; preserves the *other* server's settings (only the target port changes).
- Confirms before overwriting an existing config (shows current ports + installed services); `-y`/`--yes` skips the prompt.
- The binary now reads config from the OS-standard file on startup (`Config::load()`), so the installed service picks up the configured port.

### `service start|stop|restart`
- Detects installed services. Single install → acts directly; both proxy + client → interactive picker; `--mode <proxy|client>` skips the TUI.
- Root-gated. Per-OS control via systemctl / launchctl / sc.

## Test Plan
- [x] `cargo test` — all suites pass (90 tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manually verified on macOS: `sudo wakezilla setup` installs a LaunchDaemon that auto-starts (confirmed `state = running`, `curl 127.0.0.1:3000` → HTTP 200), survives reboot via `RunAtLoad`.
- [ ] Verify `service start/stop/restart` on macOS (needs sudo)
- [ ] Verify on Linux (systemd) and Windows

## Notes
- Pre-existing flaky tests: env-var races in `web.rs` / `proxy_server.rs` unit tests (`set_var` without a shared lock). Pass under `--test-threads=1`. Not introduced by this PR; can be fixed in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive setup wizard for configuring auto-start system services
  * Service lifecycle management (start, stop, restart installed services)
  * Persistent configuration storage in OS-standard locations

* **Documentation**
  * Added system service setup and management instructions to README

* **Tests**
  * Expanded test coverage for configuration persistence and service functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->