### PR TITLE
docs: add TUI demo gif and usage examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,22 @@ docker run -d \
    You can check the health of the client server by visiting:
    http://<client-ip>:3001/health
 
+### Run the terminal UI (TUI)
+
+Manage your machines from the terminal — no browser required. Point the TUI at
+a running proxy server:
+
+```bash
+ wakezilla tui --api-url http://192.168.1.200:3000
+```
+
+`--api-url` defaults to `http://127.0.0.1:3000`, so it can be omitted when the
+proxy server runs on the same host:
+
+```bash
+ wakezilla tui
+```
+
 ### Set up auto-start (system service)
 
 1. **Run the interactive setup wizard** (requires `sudo`/admin privileges):
@@ -166,6 +182,29 @@ Access the web interface at `http://<server-ip>:3000` to:
 - View network scan results
 - Send WOL packets manually
 - Configure automatic shutdown settings
+
+### Terminal UI (TUI)
+
+Prefer the terminal? Run `wakezilla tui --api-url http://<server-ip>:3000` to
+browse your machines, watch their online/offline status, and act on them without
+leaving the shell.
+
+![Wakezilla TUI demo](https://vhs.charm.sh/vhs-2RN0TE9RlTeQaDowRdIAZ8.gif)
+
+The left pane lists every registered machine with a live **ON**/**OFF** status;
+the right pane shows the details and port forwards of the selected machine.
+
+Key bindings:
+
+| Key     | Action                                  |
+|---------|-----------------------------------------|
+| `j` / `↓` | Move selection down                   |
+| `k` / `↑` | Move selection up                     |
+| `r`     | Refresh the machine list and statuses   |
+| `w`     | Send a Wake-on-LAN packet to the machine |
+| `t`     | Turn off the machine                    |
+| `d`     | Delete the machine (asks to confirm)    |
+| `q` / `Esc` | Quit                                |
 
 ### Adding Machines
 1. Navigate to the web interface


### PR DESCRIPTION
## What

Document the `wakezilla tui` terminal UI in the README, with a recorded demo gif.

![Wakezilla TUI demo](https://vhs.charm.sh/vhs-2RN0TE9RlTeQaDowRdIAZ8.gif)

## Changes

- **README** — new **Terminal UI (TUI)** section under Usage (demo gif + key-binding table) and a **Run the terminal UI (TUI)** subsection with `wakezilla tui --api-url ...` examples and the default api-url.
- **scripts/tui-demo.tape** — the VHS tape that records the gif.
- **scripts/record-tui-demo.sh** — reproducible setup: builds the binary, seeds a throwaway proxy-server with three sample machines, fakes their `/health` endpoints so the TUI shows a mix of ON/OFF states, then drives the recording via VHS.
- **assets/wakezilla-tui.gif** — local copy of the gif (the README references the hosted vhs.charm.sh URL).

## How it was recorded

```bash
./scripts/record-tui-demo.sh   # requires vhs, ffmpeg, python3, cargo
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced documentation with a new Terminal UI (TUI) section covering how to launch and use the interface, including navigation tips, configuration options, and a complete keyboard shortcuts reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->