### PR TITLE
fix(install): make GITHUB_TOKEN optional with unauthenticated fallback

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -183,18 +183,25 @@ available_targets_from_json() {
 
 github_api() {
   url="$1"
+
+  # A token is never required for public repositories. When one is present we
+  # try it first, but fall back to an unauthenticated request if it fails (for
+  # example a stale or invalid GITHUB_TOKEN left in the environment).
   if [ -n "${GITHUB_TOKEN:-}" ]; then
-    curl -fsSL \
+    if curl -fsSL \
       -H "Accept: application/vnd.github+json" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       -H "Authorization: Bearer $GITHUB_TOKEN" \
-      "$url"
-  else
-    curl -fsSL \
-      -H "Accept: application/vnd.github+json" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      "$url"
+      "$url"; then
+      return 0
+    fi
+    warn "GitHub request with GITHUB_TOKEN failed; retrying without authentication"
   fi
+
+  curl -fsSL \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$url"
 }
 
 fetch_release_json() {


### PR DESCRIPTION
## Problem

A user installing on a Raspberry Pi hit:

```
curl: (22) The requested URL returned error: 401
error[download]: failed to fetch release metadata from GitHub
```

The cause was a stale `GITHUB_TOKEN` present in their environment. The installer forwarded that token to the GitHub API, and because the token was invalid/expired the request was rejected with `401`. A token is **never** required to fetch release metadata for this public repository.

## Fix

`github_api()` in `install.sh` now treats `GITHUB_TOKEN` as fully optional:

- If `GITHUB_TOKEN` is set, it tries the authenticated request first and returns on success.
- If the authenticated request fails (e.g. a stale/invalid token), it prints a warning and falls back to an **unauthenticated** request.
- If no token is set, it uses the unauthenticated request directly (the default path).

This means a stale or invalid token in the environment no longer breaks installation.

## Testing

`sh scripts/test-install-sh.sh` passes (`install.sh tests passed`, exit 0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GitHub API request handling with improved fallback behavior when authenticated requests fail, ensuring more reliable installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->