### PR TITLE
fix(install): glibc/musl fallback, sudo-friendly install, absolute machines.json path in logs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ Options:
 Environment variables:
   VERSION         Version to install, without leading v (example: 0.1.49)
   BIN_DIR         Binary installation directory
-  PREFIX          Installation prefix used when BIN_DIR is unset (default: $HOME/.local)
+  PREFIX          Installation prefix used when BIN_DIR is unset (default: $HOME/.local, or /usr/local when run as root)
   TARGET          Override target triple (example: x86_64-unknown-linux-gnu)
   REPO            GitHub repository (default: guibeira/wakezilla)
   GITHUB_TOKEN    Token for authenticated GitHub API requests
@@ -114,10 +114,15 @@ parse_args() {
 }
 
 resolve_bin_dir() {
+  euid="${WAKEZILLA_EUID:-$(id -u 2>/dev/null || printf '')}"
   if [ -n "${BIN_DIR:-}" ]; then
     printf '%s\n' "$BIN_DIR"
   elif [ -n "${PREFIX:-}" ]; then
     printf '%s/bin\n' "$PREFIX"
+  elif [ "$euid" = "0" ]; then
+    # Running as root (e.g. curl ... | sudo sh): install into a system path on
+    # sudo's secure_path so `sudo wakezilla` works without extra setup.
+    printf '/usr/local/bin\n'
   elif [ -n "${HOME:-}" ]; then
     printf '%s/.local/bin\n' "$HOME"
   else

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,7 @@ Environment variables:
   TARGET          Override target triple (example: x86_64-unknown-linux-gnu)
   REPO            GitHub repository (default: guibeira/wakezilla)
   GITHUB_TOKEN    Token for authenticated GitHub API requests
+  WAKEZILLA_SUDO_SYMLINK  yes|no to skip the prompt for the /usr/local/bin symlink
 
 Examples:
   curl -fsSL https://raw.githubusercontent.com/guibeira/wakezilla/main/install.sh | sh
@@ -395,6 +396,72 @@ binary_runs() {
   "$bin_dir/$BIN_NAME" --version >/dev/null 2>&1
 }
 
+# Directories on sudo's default secure_path. A binary in one of these is
+# reachable by `sudo <bin>` without extra setup.
+SECURE_PATH_DIRS="/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin"
+
+bin_dir_on_secure_path() {
+  for secure_dir in $SECURE_PATH_DIRS; do
+    [ "$1" = "$secure_dir" ] && return 0
+  done
+  return 1
+}
+
+# A user-level install lands outside sudo's secure_path, so `sudo wakezilla
+# setup` fails with "command not found". Offer to symlink the binary into
+# /usr/local/bin (the one secure_path dir conventionally meant for local
+# installs). The install itself stays sudo-free; only this opt-in step uses it.
+offer_sudo_symlink() {
+  symlink_bin_dir="$1"
+  symlink_link_dir="/usr/local/bin"
+  symlink_link_path="$symlink_link_dir/$BIN_NAME"
+  symlink_src="$symlink_bin_dir/$BIN_NAME"
+
+  # Root installs already land on secure_path; nothing to link.
+  euid="${WAKEZILLA_EUID:-$(id -u 2>/dev/null || printf '')}"
+  [ "$euid" = "0" ] && return 0
+
+  # Binary is already reachable by sudo.
+  bin_dir_on_secure_path "$symlink_bin_dir" && return 0
+
+  # Without sudo we cannot write into the system path.
+  command -v sudo >/dev/null 2>&1 || return 0
+
+  # Already linked where we want it.
+  if [ -L "$symlink_link_path" ] && \
+     [ "$(readlink "$symlink_link_path" 2>/dev/null)" = "$symlink_src" ]; then
+    return 0
+  fi
+
+  decision="${WAKEZILLA_SUDO_SYMLINK:-ask}"
+  if [ "$decision" = "ask" ]; then
+    if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+      {
+        printf '\nTo run privileged commands like '\''sudo %s setup'\'' the binary must be on\n' "$BIN_NAME"
+        printf 'sudo'\''s PATH. Link %s -> %s now? (needs sudo) [y/N] ' "$symlink_link_path" "$symlink_src"
+      } > /dev/tty
+      read symlink_answer < /dev/tty || symlink_answer=
+      case "$symlink_answer" in
+        y|Y|yes|YES|Yes) decision=yes ;;
+        *) decision=no ;;
+      esac
+    else
+      decision=no
+    fi
+  fi
+
+  if [ "$decision" != "yes" ]; then
+    info "to run privileged commands, use: sudo env \"PATH=\$PATH\" $BIN_NAME ... (or: sudo $symlink_src ...)"
+    return 0
+  fi
+
+  if sudo ln -sf "$symlink_src" "$symlink_link_path"; then
+    info "linked $symlink_link_path -> $symlink_src ('sudo $BIN_NAME' now works)"
+  else
+    warn "failed to create $symlink_link_path; run privileged commands with: sudo $symlink_src ..."
+  fi
+}
+
 if [ -n "${WAKEZILLA_INSTALL_SH_TEST_MODE:-}" ]; then
   return 0 2>/dev/null || exit 0
 fi
@@ -468,3 +535,4 @@ info "resolved $BIN_NAME v$release_version"
 info "asset: $INSTALLED_ASSET_URL"
 info "install dir: $bin_dir"
 path_guidance "$bin_dir"
+offer_sudo_symlink "$bin_dir"

--- a/scripts/test-install-sh.sh
+++ b/scripts/test-install-sh.sh
@@ -486,11 +486,40 @@ test_parse_args_rejects_two_versions() {
 test_resolve_bin_dir_default() {
   bin_dir=$(
     HOME=/tmp/wakezilla-home
+    WAKEZILLA_EUID=1000
     unset BIN_DIR || true
     unset PREFIX || true
     resolve_bin_dir
   )
   assert_eq "/tmp/wakezilla-home/.local/bin" "$bin_dir" "default bin dir"
+}
+
+test_resolve_bin_dir_root_default() {
+  bin_dir=$(
+    HOME=/root
+    WAKEZILLA_EUID=0
+    unset BIN_DIR || true
+    unset PREFIX || true
+    resolve_bin_dir
+  )
+  assert_eq "/usr/local/bin" "$bin_dir" "root default bin dir"
+}
+
+test_resolve_bin_dir_root_respects_overrides() {
+  bin_dir=$(
+    WAKEZILLA_EUID=0
+    BIN_DIR=/custom/bin
+    resolve_bin_dir
+  )
+  assert_eq "/custom/bin" "$bin_dir" "root BIN_DIR override"
+
+  bin_dir=$(
+    WAKEZILLA_EUID=0
+    unset BIN_DIR || true
+    PREFIX=/opt/wakezilla
+    resolve_bin_dir
+  )
+  assert_eq "/opt/wakezilla/bin" "$bin_dir" "root PREFIX override"
 }
 
 test_resolve_bin_dir_prefix() {
@@ -513,6 +542,7 @@ test_resolve_bin_dir_override() {
 
 test_resolve_bin_dir_requires_home_for_default() {
   if output=$(
+    WAKEZILLA_EUID=1000
     unset BIN_DIR || true
     unset PREFIX || true
     unset HOME || true
@@ -539,6 +569,8 @@ if test_install_argument_helpers_defined; then
   test_parse_args_positional_version
   test_parse_args_rejects_two_versions
   test_resolve_bin_dir_default
+  test_resolve_bin_dir_root_default
+  test_resolve_bin_dir_root_respects_overrides
   test_resolve_bin_dir_prefix
   test_resolve_bin_dir_override
   test_resolve_bin_dir_requires_home_for_default

--- a/scripts/test-install-sh.sh
+++ b/scripts/test-install-sh.sh
@@ -453,6 +453,38 @@ test_musl_fallback_target_none() {
   assert_eq "" "$(musl_fallback_target aarch64-apple-darwin)" "darwin target has no fallback"
 }
 
+test_bin_dir_on_secure_path() {
+  assert_command_exists bin_dir_on_secure_path "secure path helper" || return 0
+  if bin_dir_on_secure_path /usr/local/bin; then
+    :
+  else
+    fail "secure path: expected /usr/local/bin to be on secure_path"
+  fi
+  if bin_dir_on_secure_path /home/pi/.local/bin; then
+    fail "secure path: expected ~/.local/bin to be off secure_path"
+  fi
+}
+
+test_offer_sudo_symlink_skips_when_disabled() {
+  assert_command_exists offer_sudo_symlink "sudo symlink helper" || return 0
+  # decision=no must never invoke sudo; it should print the manual hint and
+  # return cleanly even when the binary is off secure_path.
+  output=$(WAKEZILLA_EUID=1000 WAKEZILLA_SUDO_SYMLINK=no offer_sudo_symlink /tmp/wakezilla-bin 2>&1)
+  assert_contains "$output" "sudo env" "sudo symlink disabled hint"
+}
+
+test_offer_sudo_symlink_noop_for_root() {
+  assert_command_exists offer_sudo_symlink "sudo symlink helper" || return 0
+  output=$(WAKEZILLA_EUID=0 WAKEZILLA_SUDO_SYMLINK=no offer_sudo_symlink /tmp/wakezilla-bin 2>&1)
+  assert_eq "" "$output" "root sudo symlink noop"
+}
+
+test_offer_sudo_symlink_noop_on_secure_path() {
+  assert_command_exists offer_sudo_symlink "sudo symlink helper" || return 0
+  output=$(WAKEZILLA_EUID=1000 WAKEZILLA_SUDO_SYMLINK=yes offer_sudo_symlink /usr/local/bin 2>&1)
+  assert_eq "" "$output" "secure path sudo symlink noop"
+}
+
 test_install_argument_helpers_defined() {
   missing=0
   assert_command_exists parse_args "parse args helper" || missing=1
@@ -565,6 +597,10 @@ test_detect_target_linux_arm64_musl
 test_detect_target_unsupported_platform
 test_musl_fallback_target_gnu
 test_musl_fallback_target_none
+test_bin_dir_on_secure_path
+test_offer_sudo_symlink_skips_when_disabled
+test_offer_sudo_symlink_noop_for_root
+test_offer_sudo_symlink_noop_on_secure_path
 if test_install_argument_helpers_defined; then
   test_parse_args_positional_version
   test_parse_args_rejects_two_versions

--- a/src/web.rs
+++ b/src/web.rs
@@ -37,15 +37,25 @@ const DEFAULT_DB_PATH: &str = "machines.json";
 
 fn machines_db_path() -> PathBuf {
     // First check for environment variable override
-    if let Ok(path) = std::env::var("WAKEZILLA__STORAGE__MACHINES_DB_PATH") {
-        return PathBuf::from(path);
-    }
+    let path = if let Ok(path) = std::env::var("WAKEZILLA__STORAGE__MACHINES_DB_PATH") {
+        PathBuf::from(path)
+    } else {
+        // Use current working directory as default (not executable directory)
+        // This ensures the file is saved/loaded from where the user runs the command
+        env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(DEFAULT_DB_PATH)
+    };
 
-    // Use current working directory as default (not executable directory)
-    // This ensures the file is saved/loaded from where the user runs the command
-    env::current_dir()
-        .unwrap_or_else(|_| PathBuf::from("."))
-        .join(DEFAULT_DB_PATH)
+    // Always resolve to an absolute path so logs show the full location instead
+    // of a bare "machines.json" relative to the (often unclear) working dir.
+    if path.is_absolute() {
+        path
+    } else {
+        env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    }
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -182,9 +192,9 @@ pub fn load_machines_from_path<P: AsRef<Path>>(path: P) -> Result<Vec<Machine>> 
         serde_json::from_str(&data).with_context(|| "Failed to parse machines database")?;
 
     info!(
-        "Successfully loaded {} machines from database at {:?}",
+        "Successfully loaded {} machines from database at {}",
         machines.len(),
-        path_ref
+        path_ref.display()
     );
     Ok(machines)
 }


### PR DESCRIPTION
## Problems

Hit while installing/running on a Raspberry Pi:

1. **`GLIBC_2.39' not found`** — `aarch64-unknown-linux-gnu` is built on `ubuntu-24.04-arm` (glibc 2.39). The script detects glibc, downloads the gnu build, and it aborts on older-glibc hosts (Raspberry Pi OS bookworm 2.36 / bullseye 2.31); glibc is forward-compatible only.
2. **`sudo wakezilla: command not found`** — a user-level install lands in `~/.local/bin`, which is not on sudo's `secure_path`, so privileged subcommands (`sudo wakezilla setup`, `sudo wakezilla service ...`) cannot find the binary.
3. **Ambiguous machines.json path in logs** — the load/save log lines could print a bare relative `machines.json`, hiding where the DB actually lives.

## Changes

### `install.sh`
- **musl fallback**: after install the script runs `--version`; if a gnu Linux binary fails to run and an equivalent musl asset exists, it re-downloads and reinstalls the static musl build (no glibc requirement). Refactored into `download_and_install_target`; new `musl_fallback_target` helper. Fixes existing and future releases without a CI rebuild.
- **root install location**: when run as root (`curl ... | sudo sh`) with no `BIN_DIR`/`PREFIX`, install into `/usr/local/bin` (on `secure_path`).
- **opt-in sudo symlink**: after a non-root install, if the bin dir is off `secure_path` and sudo is available, the script *offers* to symlink the binary into `/usr/local/bin`. Install stays sudo-free by default — the prompt defaults to **No** and is skipped entirely when there is no TTY. `WAKEZILLA_SUDO_SYMLINK=yes|no` answers non-interactively.

### `src/web.rs`
- `machines_db_path()` now always resolves to an absolute path, and the load/save logs print it with `Display`, so logs show the full location instead of a bare relative `machines.json`.

## Usage matrix

- Normal use (proxy-server / client-server / tui): no sudo to install, no sudo to run.
- systemd (`setup` / `service`): needs sudo to run. Either install as root (`curl ... | sudo sh` → `/usr/local/bin`), or accept the symlink prompt during a user install.

## Tests

`scripts/test-install-sh.sh`: added coverage for `musl_fallback_target`, root default bin dir + override precedence, `bin_dir_on_secure_path`, and `offer_sudo_symlink` no-op paths.
`cargo test --lib web::tests`: passes.

Workaround for already-installed users (no upgrade needed):
```sh
curl -fsSL https://wakezilla.dev/install.sh | TARGET=aarch64-unknown-linux-musl sh
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Install script now correctly defaults to /usr/local/bin for root installs and resolves storage path values to absolute paths.

* **New Features**
  * Installer can optionally offer to create a privileged /usr/local/bin symlink (opt-in prompt) to make the tool available on PATH.

* **Documentation**
  * Install help text updated to document prefix/bin defaults for root vs non-root runs.

* **Tests**
  * Added tests for root/non-root install behavior, secure-path handling, and sudo-symlink scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->