### PR TITLE
fix installer tty prompt in CI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -407,6 +407,19 @@ bin_dir_on_secure_path() {
   return 1
 }
 
+prompt_sudo_symlink() {
+  {
+    printf '\nTo run privileged commands like '\''sudo %s setup'\'' the binary must be on\n' "$BIN_NAME"
+    printf 'sudo'\''s PATH. Link %s -> %s now? (needs sudo) [y/N] ' "$symlink_link_path" "$symlink_src"
+  } 2>/dev/null > /dev/tty || return 1
+
+  IFS= read -r symlink_answer 2>/dev/null < /dev/tty || symlink_answer=
+  case "$symlink_answer" in
+    y|Y|yes|YES|Yes) decision=yes ;;
+    *) decision=no ;;
+  esac
+}
+
 # A user-level install lands outside sudo's secure_path, so `sudo wakezilla
 # setup` fails with "command not found". Offer to symlink the binary into
 # /usr/local/bin (the one secure_path dir conventionally meant for local
@@ -435,17 +448,7 @@ offer_sudo_symlink() {
 
   decision="${WAKEZILLA_SUDO_SYMLINK:-ask}"
   if [ "$decision" = "ask" ]; then
-    if [ -r /dev/tty ] && [ -w /dev/tty ]; then
-      {
-        printf '\nTo run privileged commands like '\''sudo %s setup'\'' the binary must be on\n' "$BIN_NAME"
-        printf 'sudo'\''s PATH. Link %s -> %s now? (needs sudo) [y/N] ' "$symlink_link_path" "$symlink_src"
-      } > /dev/tty
-      read symlink_answer < /dev/tty || symlink_answer=
-      case "$symlink_answer" in
-        y|Y|yes|YES|Yes) decision=yes ;;
-        *) decision=no ;;
-      esac
-    else
+    if ! prompt_sudo_symlink; then
       decision=no
     fi
   fi

--- a/scripts/test-install-sh.sh
+++ b/scripts/test-install-sh.sh
@@ -467,10 +467,26 @@ test_bin_dir_on_secure_path() {
 
 test_offer_sudo_symlink_skips_when_disabled() {
   assert_command_exists offer_sudo_symlink "sudo symlink helper" || return 0
+  temp_dir=$(mktemp -d)
+  mkdir -p "$temp_dir/bin"
+  cat > "$temp_dir/bin/sudo" <<'SH'
+#!/usr/bin/env sh
+printf 'sudo should not be invoked\n' >&2
+exit 1
+SH
+  chmod +x "$temp_dir/bin/sudo"
+  old_path="$PATH"
+  PATH="$temp_dir/bin:$PATH"
+
   # decision=no must never invoke sudo; it should print the manual hint and
   # return cleanly even when the binary is off secure_path.
   output=$(WAKEZILLA_EUID=1000 WAKEZILLA_SUDO_SYMLINK=no offer_sudo_symlink /tmp/wakezilla-bin 2>&1)
+  PATH="$old_path"
+  export PATH
+  rm -rf "$temp_dir"
+
   assert_contains "$output" "sudo env" "sudo symlink disabled hint"
+  assert_not_contains "$output" "sudo should not be invoked" "sudo symlink disabled does not run sudo"
 }
 
 test_offer_sudo_symlink_noop_for_root() {


### PR DESCRIPTION
## Summary
- make the optional sudo symlink prompt tolerate non-interactive runners without an attached tty
- keep installer tests self-contained by stubbing sudo in the disabled-symlink case

## Root cause
`offer_sudo_symlink` checked `/dev/tty` with `-r/-w`, but GitHub Actions can report the device as accessible while opening it still fails. With `set -e`, that aborted `install.sh` with status 2 after the install completed.

## Validation
- `sh -n install.sh scripts/test-install-sh.sh && scripts/test-install-sh.sh`
- amd64 Ubuntu 24.04 container, non-root user with sudo: `install.sh tests passed`
- amd64 Ubuntu 24.04 minimal container without sudo: `install.sh tests passed`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the sudo symlink prompting flow during installation by extracting prompting logic into a dedicated helper function.

* **Tests**
  * Expanded test coverage for the disabled sudo symlink scenario with validation that sudo is not invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->