### PR TITLE
Fix coverage env test race

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,6 @@ pub mod web;
 pub mod wol;
 
 pub use api_models::*;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ mod scanner;
 mod service;
 mod setup;
 mod system;
+#[cfg(test)]
+mod test_support;
 mod tui;
 mod web;
 mod wol;

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -535,7 +535,6 @@ mod tests {
         response::IntoResponse,
         Json,
     };
-    use once_cell::sync::Lazy;
     use std::collections::HashMap;
     use std::io::ErrorKind;
     use std::net::Ipv4Addr;
@@ -544,8 +543,6 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::sync::{watch, Mutex as AsyncMutex, RwLock};
-
-    static ENV_LOCK: Lazy<std::sync::Mutex<()>> = Lazy::new(|| std::sync::Mutex::new(()));
 
     struct EnvGuard {
         key: &'static str,
@@ -651,7 +648,9 @@ mod tests {
     // across the awaited handler call, so the sync guard intentionally spans the await point.
     #[allow(clippy::await_holding_lock)]
     async fn add_machine_api_persists_new_entry() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test_support::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("machines.json");
         let _guard = EnvGuard::set_path("WAKEZILLA__STORAGE__MACHINES_DB_PATH", &file_path);
@@ -782,7 +781,9 @@ mod tests {
     // across the awaited handler call, so the sync guard intentionally spans the await point.
     #[allow(clippy::await_holding_lock)]
     async fn update_machine_api_applies_changes() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test_support::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("machines.json");
         let _guard = EnvGuard::set_path("WAKEZILLA__STORAGE__MACHINES_DB_PATH", &file_path);
@@ -824,7 +825,9 @@ mod tests {
     // across the awaited handler call, so the sync guard intentionally spans the await point.
     #[allow(clippy::await_holding_lock)]
     async fn delete_machine_api_stops_proxy_and_removes_machine() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test_support::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("machines.json");
         let _guard = EnvGuard::set_path("WAKEZILLA__STORAGE__MACHINES_DB_PATH", &file_path);

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,1 @@
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/src/web.rs
+++ b/src/web.rs
@@ -271,11 +271,8 @@ pub fn restart_global_monitor(state: &AppState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use once_cell::sync::Lazy;
     use std::net::Ipv4Addr;
     use tempfile::{tempdir, NamedTempFile};
-
-    static ENV_LOCK: Lazy<std::sync::Mutex<()>> = Lazy::new(|| std::sync::Mutex::new(()));
 
     struct EnvGuard {
         key: &'static str,
@@ -350,7 +347,9 @@ mod tests {
 
     #[test]
     fn save_machines_writes_using_configured_path() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = crate::test_support::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("machines.json");
         let _guard = EnvGuard::set_path("WAKEZILLA__STORAGE__MACHINES_DB_PATH", &file_path);


### PR DESCRIPTION
## Summary
- Add a shared test-only environment mutex used by both library and binary test crate roots.
- Update env-mutating web and proxy server tests to use the shared lock.

## Root cause
The coverage job runs tests in parallel, and multiple tests mutate `WAKEZILLA__STORAGE__MACHINES_DB_PATH`. The web and proxy server test modules had separate locks, so one test could restore or remove the env var while another still expected its temp database path.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p wakezilla --lib`
- `cargo test --workspace`
- `cargo llvm-cov --workspace --cobertura --output-path cobertura.xml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored internal test infrastructure to consolidate synchronization mechanisms across test modules.

* **Chores**
  * Reorganized test support utilities into a dedicated module for improved maintainability.

---

**Note:** This release contains no end-user visible changes. All modifications are internal testing improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->