### PR TITLE
Add self update command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if 1.0.3",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,10 +1037,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if 1.0.3",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2135,6 +2164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2674,7 +2704,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3310,6 +3340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,6 +3506,17 @@ dependencies = [
  "throw_error",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4199,6 +4246,7 @@ dependencies = [
  "config 0.14.1",
  "crossterm",
  "dns-lookup",
+ "flate2",
  "futures-util",
  "http-body-util",
  "include_dir",
@@ -4209,8 +4257,11 @@ dependencies = [
  "ratatui",
  "regex",
  "reqwest",
+ "semver 1.0.27",
  "serde",
  "serde_json",
+ "sha2",
+ "tar",
  "tempfile",
  "tokio 1.47.1",
  "toml 0.8.23",
@@ -4881,6 +4932,16 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,10 +71,14 @@ tower-http  = {version = "0.6.6", features = [ "cors", "fs"] }
 mime_guess = "2.0"
 include_dir = "0.7.4"
 wakezilla-common = { path = "common", version = "0.1.0" }
+semver = "1.0"
+sha2 = "0.10"
+flate2 = "1.0"
+tar = "0.4"
+tempfile = "3"
 
 [dev-dependencies]
 http-body-util = "0.1"
-tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,32 @@ docker run -d \
    ```bash
    wakezilla --version
    ```
+
+### Update Wakezilla
+
+Install the latest GitHub Release for your platform:
+
+```bash
+wakezilla update
+```
+
+To install a specific version, pass it without the leading `v`:
+
+```bash
+wakezilla update --version 0.2.3
+```
+
+Wakezilla checks for newer releases when the binary starts and prints a warning
+when one is available. Use `--no-update-check` for offline or scripted runs:
+
+```bash
+wakezilla --no-update-check proxy-server
+```
+
+If Wakezilla was installed into a system directory such as `/usr/local/bin`, the
+update may require elevated privileges. A failed update leaves the existing
+binary untouched.
+
 ### Run proxy server 
 
 1. **Run the Server**:
@@ -152,6 +178,10 @@ proxy server runs on the same host:
    overwriting. Existing settings for the *other* server are preserved — only
    the target server's port is updated. Pass `-y`/`--yes` to skip the
    confirmation for non-interactive use.
+
+   Services installed by `setup` run with `--no-update-check`, so background
+   services do not make startup network requests. Run `wakezilla update`
+   manually when you want to upgrade the installed binary.
 
 2. **Control an installed service** (requires `sudo`/admin privileges):
    ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod scanner;
 pub mod service;
 pub mod setup;
 pub mod system;
+pub mod update;
 pub mod web;
 pub mod wol;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod system;
 #[cfg(test)]
 mod test_support;
 mod tui;
+mod update;
 mod web;
 mod wol;
 
@@ -25,6 +26,10 @@ use setup::{ServiceArgs, SetupArgs};
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 pub struct Cli {
+    /// Skip the automatic startup check for a newer Wakezilla release.
+    #[arg(long, global = true, help_heading = "Global Options")]
+    no_update_check: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -43,6 +48,16 @@ pub enum Commands {
     Setup(SetupArgs),
     /// Control an installed Wakezilla service (start/stop/restart/status/logs)
     Service(ServiceArgs),
+    /// Download and install a Wakezilla release
+    Update(UpdateArgs),
+}
+
+#[derive(Parser, Debug)]
+#[command()]
+pub struct UpdateArgs {
+    /// Version to install, without leading `v`. Defaults to the latest release.
+    #[arg(long, help_heading = "Update Options")]
+    version: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -129,6 +144,12 @@ async fn main() -> Result<()> {
 
     init_tracing();
 
+    if should_check_for_updates(&cli) {
+        if let Err(e) = update::warn_if_update_available(env!("CARGO_PKG_VERSION")).await {
+            tracing::warn!("Update check failed: {e}");
+        }
+    }
+
     match cli.command {
         Commands::Tui(args) => {
             tui::run(tui::TuiConfig {
@@ -169,9 +190,23 @@ async fn main() -> Result<()> {
                 std::process::exit(1);
             }
         }
+        Commands::Update(args) => {
+            update::run_update(update::UpdateRequest {
+                version: args.version,
+            })
+            .await?;
+        }
     }
 
     Ok(())
+}
+
+fn should_check_for_updates(cli: &Cli) -> bool {
+    if cli.no_update_check {
+        return false;
+    }
+
+    !matches!(cli.command, Commands::Setup(_) | Commands::Update(_))
 }
 
 fn init_tracing() {
@@ -254,6 +289,51 @@ mod cli_tests {
             Commands::Tui(args) => assert_eq!(args.api_url, "http://127.0.0.1:3000"),
             other => panic!("expected Tui command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn cli_accepts_global_no_update_check_before_subcommand() {
+        let cli = Cli::try_parse_from(["wakezilla", "--no-update-check", "proxy-server"])
+            .expect("global no-update-check parses");
+
+        assert!(cli.no_update_check);
+    }
+
+    #[test]
+    fn cli_accepts_update_without_version() {
+        let cli = Cli::try_parse_from(["wakezilla", "update"]).expect("update parses");
+
+        match cli.command {
+            Commands::Update(args) => assert!(args.version.is_none()),
+            other => panic!("expected Update command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_update_with_version() {
+        let cli = Cli::try_parse_from(["wakezilla", "update", "--version", "0.2.3"])
+            .expect("update version parses");
+
+        match cli.command {
+            Commands::Update(args) => assert_eq!(args.version.as_deref(), Some("0.2.3")),
+            other => panic!("expected Update command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn startup_update_check_is_skipped_for_setup_update_and_flag() {
+        let setup_cli = Cli::try_parse_from(["wakezilla", "setup"]).expect("setup parses");
+        assert!(!should_check_for_updates(&setup_cli));
+
+        let update_cli = Cli::try_parse_from(["wakezilla", "update"]).expect("update parses");
+        assert!(!should_check_for_updates(&update_cli));
+
+        let no_check_cli = Cli::try_parse_from(["wakezilla", "--no-update-check", "proxy-server"])
+            .expect("proxy parses");
+        assert!(!should_check_for_updates(&no_check_cli));
+
+        let proxy_cli = Cli::try_parse_from(["wakezilla", "proxy-server"]).expect("proxy parses");
+        assert!(should_check_for_updates(&proxy_cli));
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -59,10 +59,16 @@ impl Mode {
     }
 }
 
+/// Arguments passed to a Wakezilla process managed by the OS service layer.
+pub fn service_program_args(mode: Mode) -> [&'static str; 2] {
+    ["--no-update-check", mode.subcommand()]
+}
+
 /// Render a systemd unit file. `exe` is the absolute path to the wakezilla binary.
 // Platform-conditional: used by the systemd (Linux) / launchd (macOS) / Windows install paths; some are cfg'd out per-OS.
 #[allow(dead_code)]
 pub fn generate_systemd_unit(mode: Mode, exe: &str) -> String {
+    let [no_update_check, sub] = service_program_args(mode);
     format!(
         "[Unit]\n\
          Description=Wakezilla {desc}\n\
@@ -71,7 +77,7 @@ pub fn generate_systemd_unit(mode: Mode, exe: &str) -> String {
          \n\
          [Service]\n\
          Type=simple\n\
-         ExecStart={exe} {sub}\n\
+         ExecStart={exe} {no_update_check} {sub}\n\
          Restart=on-failure\n\
          RestartSec=5\n\
          \n\
@@ -79,7 +85,8 @@ pub fn generate_systemd_unit(mode: Mode, exe: &str) -> String {
          WantedBy=multi-user.target\n",
         desc = mode.subcommand(),
         exe = exe,
-        sub = mode.subcommand(),
+        no_update_check = no_update_check,
+        sub = sub,
     )
 }
 
@@ -100,6 +107,7 @@ fn macos_stderr_log(mode: Mode) -> String {
 // Platform-conditional: used by the systemd (Linux) / launchd (macOS) / Windows install paths; some are cfg'd out per-OS.
 #[allow(dead_code)]
 pub fn generate_launchd_plist(mode: Mode, exe: &str) -> String {
+    let [no_update_check, sub] = service_program_args(mode);
     format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
          <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
@@ -110,6 +118,7 @@ pub fn generate_launchd_plist(mode: Mode, exe: &str) -> String {
          \t<key>ProgramArguments</key>\n\
          \t<array>\n\
          \t\t<string>{exe}</string>\n\
+         \t\t<string>{no_update_check}</string>\n\
          \t\t<string>{sub}</string>\n\
          \t</array>\n\
          \t<key>RunAtLoad</key>\n\
@@ -124,7 +133,8 @@ pub fn generate_launchd_plist(mode: Mode, exe: &str) -> String {
          </plist>\n",
         label = mode.launchd_label(),
         exe = exe,
-        sub = mode.subcommand(),
+        no_update_check = no_update_check,
+        sub = sub,
         out = macos_stdout_log(mode),
         err = macos_stderr_log(mode),
     )
@@ -215,7 +225,8 @@ pub fn install(mode: Mode, exe: &str) -> Result<()> {
         // error "service already exists" on a re-run.
         run_ignore_err("sc", &["stop", mode.service_name()]);
         run_ignore_err("sc", &["delete", mode.service_name()]);
-        let bin_path = format!("\"{exe}\" {}", mode.subcommand());
+        let [no_update_check, sub] = service_program_args(mode);
+        let bin_path = format!("\"{exe}\" {no_update_check} {sub}");
         run(
             "sc",
             &[

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,597 @@
+use anyhow::{anyhow, bail, Context, Result};
+use flate2::read::GzDecoder;
+use semver::Version;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tar::Archive;
+
+pub const REPO_OWNER: &str = "guibeira";
+pub const REPO_NAME: &str = "wakezilla";
+pub const BIN_NAME: &str = "wakezilla";
+
+#[derive(Debug, Clone)]
+pub struct UpdateRequest {
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateStatus {
+    Current { current: String },
+    Available { current: String, latest: String },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    prerelease: bool,
+    assets: Vec<GitHubAsset>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GitHubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+pub fn normalize_tag(tag: &str) -> &str {
+    tag.strip_prefix("wakezilla/v")
+        .or_else(|| tag.strip_prefix('v'))
+        .unwrap_or(tag)
+}
+
+pub fn release_api_url(version: Option<&str>) -> String {
+    match version {
+        Some(version) => format!(
+            "https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/releases/tags/v{}",
+            normalize_tag(version)
+        ),
+        None => format!("https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/releases/latest"),
+    }
+}
+
+pub fn checksum_url(version: &str) -> String {
+    format!(
+        "https://github.com/{REPO_OWNER}/{REPO_NAME}/releases/download/v{}/SHA256SUMS",
+        normalize_tag(version)
+    )
+}
+
+fn asset_name(version: &str, target: &str) -> String {
+    format!("{BIN_NAME}-{}-{target}.tar.gz", normalize_tag(version))
+}
+
+fn target_from_parts(os: &str, arch: &str, libc: Option<&str>) -> Result<String> {
+    let arch = match arch {
+        "x86_64" | "amd64" => "x86_64",
+        "aarch64" | "arm64" => "aarch64",
+        other => bail!("unsupported architecture for Wakezilla releases: {other}"),
+    };
+
+    match os {
+        "linux" => Ok(format!(
+            "{arch}-unknown-linux-{}",
+            libc.filter(|value| !value.is_empty()).unwrap_or("gnu")
+        )),
+        "macos" | "darwin" => Ok(format!("{arch}-apple-darwin")),
+        other => bail!("unsupported OS for Wakezilla releases: {other}"),
+    }
+}
+
+pub fn detect_target() -> Result<String> {
+    let libc = if cfg!(target_os = "linux") {
+        Some(if cfg!(target_env = "musl") {
+            "musl"
+        } else {
+            "gnu"
+        })
+    } else {
+        None
+    };
+
+    target_from_parts(std::env::consts::OS, std::env::consts::ARCH, libc)
+}
+
+fn available_targets(release: &GitHubRelease) -> Vec<String> {
+    let version = normalize_tag(&release.tag_name);
+    let prefix = format!("{BIN_NAME}-{version}-");
+
+    let mut targets = release
+        .assets
+        .iter()
+        .filter_map(|asset| {
+            asset
+                .name
+                .strip_prefix(&prefix)
+                .and_then(|name| name.strip_suffix(".tar.gz"))
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+    targets.sort_unstable();
+    targets.dedup();
+    targets
+}
+
+fn select_asset<'a>(release: &'a GitHubRelease, target: &str) -> Result<&'a GitHubAsset> {
+    let version = normalize_tag(&release.tag_name);
+    let expected = asset_name(version, target);
+
+    release
+        .assets
+        .iter()
+        .find(|asset| asset.name == expected)
+        .ok_or_else(|| {
+            let available = available_targets(release);
+            anyhow!(
+                "no release asset found for target {target}; expected {expected}; available targets: {}",
+                if available.is_empty() {
+                    "none".to_string()
+                } else {
+                    available.join(", ")
+                }
+            )
+        })
+}
+
+fn status_from_release(current: &str, release: &GitHubRelease) -> Result<UpdateStatus> {
+    let latest = normalize_tag(&release.tag_name);
+    if release.prerelease {
+        return Ok(UpdateStatus::Current {
+            current: current.to_string(),
+        });
+    }
+
+    let current_version = Version::parse(current)
+        .with_context(|| format!("failed to parse current version '{current}'"))?;
+    let latest_version = Version::parse(latest)
+        .with_context(|| format!("failed to parse latest version '{latest}'"))?;
+
+    if !latest_version.pre.is_empty() {
+        return Ok(UpdateStatus::Current {
+            current: current.to_string(),
+        });
+    }
+
+    if current_version.cmp_precedence(&latest_version).is_lt() {
+        Ok(UpdateStatus::Available {
+            current: current.to_string(),
+            latest: latest.to_string(),
+        })
+    } else {
+        Ok(UpdateStatus::Current {
+            current: current.to_string(),
+        })
+    }
+}
+
+fn github_request(client: &reqwest::Client, url: &str) -> reqwest::RequestBuilder {
+    let request = client
+        .get(url)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header(
+            reqwest::header::USER_AGENT,
+            format!("{BIN_NAME}/{}", env!("CARGO_PKG_VERSION")),
+        );
+
+    match std::env::var("GITHUB_TOKEN") {
+        Ok(token) if !token.trim().is_empty() => request.bearer_auth(token),
+        _ => request,
+    }
+}
+
+async fn fetch_release(client: &reqwest::Client, version: Option<&str>) -> Result<GitHubRelease> {
+    let url = release_api_url(version);
+    let response = github_request(client, &url)
+        .send()
+        .await
+        .with_context(|| format!("failed to fetch release metadata from {url}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        bail!("GitHub release request failed with {status} for {url}");
+    }
+
+    response
+        .json::<GitHubRelease>()
+        .await
+        .context("failed to parse GitHub release metadata")
+}
+
+async fn download_bytes(client: &reqwest::Client, url: &str, label: &str) -> Result<Vec<u8>> {
+    let response = github_request(client, url)
+        .send()
+        .await
+        .with_context(|| format!("failed to download {label}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        bail!("download failed with {status} for {label}");
+    }
+
+    Ok(response
+        .bytes()
+        .await
+        .with_context(|| format!("failed to read downloaded {label}"))?
+        .to_vec())
+}
+
+pub async fn check_latest(client: &reqwest::Client, current: &str) -> Result<UpdateStatus> {
+    let release = fetch_release(client, None).await?;
+    status_from_release(current, &release)
+}
+
+pub async fn warn_if_update_available(current: &str) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+        .context("failed to create update check HTTP client")?;
+
+    if let UpdateStatus::Available { current, latest } = check_latest(&client, current).await? {
+        tracing::warn!(
+            "Wakezilla {latest} is available (current {current}). Run `wakezilla update` to update."
+        );
+    }
+
+    Ok(())
+}
+
+fn checksum_for_asset(checksums: &str, asset_name: &str) -> Result<String> {
+    checksums
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.split_whitespace();
+            let hash = parts.next()?;
+            let name = parts.next()?.trim_start_matches('*');
+            (name == asset_name).then(|| hash.to_string())
+        })
+        .next()
+        .ok_or_else(|| anyhow!("checksum not found for {asset_name}"))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut output, "{byte:02x}").expect("writing to string should not fail");
+    }
+    output
+}
+
+fn verify_checksum_bytes(bytes: &[u8], checksums: &str, asset_name: &str) -> Result<()> {
+    let expected = checksum_for_asset(checksums, asset_name)?;
+    let actual = sha256_hex(bytes);
+    if actual.eq_ignore_ascii_case(&expected) {
+        Ok(())
+    } else {
+        bail!("checksum verification failed for {asset_name}")
+    }
+}
+
+fn extract_binary(archive_path: &Path, out_dir: &Path, bin_name: &str) -> Result<PathBuf> {
+    fs::create_dir_all(out_dir).with_context(|| {
+        format!(
+            "failed to create extraction directory {}",
+            out_dir.display()
+        )
+    })?;
+
+    let file = fs::File::open(archive_path)
+        .with_context(|| format!("failed to open {}", archive_path.display()))?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+    archive
+        .unpack(out_dir)
+        .with_context(|| format!("failed to extract {}", archive_path.display()))?;
+
+    let direct = out_dir.join(bin_name);
+    if direct.is_file() {
+        return Ok(direct);
+    }
+
+    let mut pending = vec![out_dir.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        for entry in
+            fs::read_dir(&dir).with_context(|| format!("failed to read {}", dir.display()))?
+        {
+            let entry = entry.context("failed to read extracted archive entry")?;
+            let path = entry.path();
+            let file_type = entry
+                .file_type()
+                .with_context(|| format!("failed to read file type for {}", path.display()))?;
+            if file_type.is_dir() {
+                pending.push(path);
+            } else if file_type.is_file() && entry.file_name() == bin_name {
+                return Ok(path);
+            }
+        }
+    }
+
+    bail!("binary {bin_name} not found in downloaded asset")
+}
+
+fn install_binary(src: &Path, dst: &Path) -> Result<()> {
+    let parent = dst
+        .parent()
+        .ok_or_else(|| anyhow!("destination has no parent directory: {}", dst.display()))?;
+    if !parent.is_dir() {
+        bail!("destination directory does not exist: {}", parent.display());
+    }
+
+    let tmp = parent.join(format!(".{BIN_NAME}.update.{}.tmp", std::process::id()));
+    if tmp.exists() {
+        fs::remove_file(&tmp).with_context(|| format!("failed to remove {}", tmp.display()))?;
+    }
+
+    fs::copy(src, &tmp).with_context(|| {
+        format!(
+            "failed to stage updated binary at {}. Try rerunning with appropriate privileges.",
+            tmp.display()
+        )
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("failed to mark {} executable", tmp.display()))?;
+    }
+
+    if let Err(err) = fs::rename(&tmp, dst) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err).with_context(|| {
+            format!(
+                "failed to replace {}. Try rerunning with appropriate privileges.",
+                dst.display()
+            )
+        });
+    }
+
+    Ok(())
+}
+
+pub async fn run_update(request: UpdateRequest) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .build()
+        .context("failed to create update HTTP client")?;
+
+    let release = fetch_release(&client, request.version.as_deref()).await?;
+    let release_version = normalize_tag(&release.tag_name).to_string();
+
+    if request.version.is_none() {
+        match status_from_release(env!("CARGO_PKG_VERSION"), &release)? {
+            UpdateStatus::Current { current } => {
+                println!("wakezilla is already up to date ({current}).");
+                return Ok(());
+            }
+            UpdateStatus::Available { .. } => {}
+        }
+    }
+
+    let target = detect_target()?;
+    let asset = select_asset(&release, &target)?.clone();
+    let checksums_url = checksum_url(&release_version);
+
+    println!("Installing wakezilla v{release_version} for {target}...");
+
+    let archive_bytes = download_bytes(&client, &asset.browser_download_url, &asset.name).await?;
+    let checksums_bytes = download_bytes(&client, &checksums_url, "SHA256SUMS").await?;
+    let checksums = String::from_utf8(checksums_bytes).context("SHA256SUMS was not valid UTF-8")?;
+    verify_checksum_bytes(&archive_bytes, &checksums, &asset.name)?;
+
+    let tmpdir = tempfile::tempdir().context("failed to create temporary update directory")?;
+    let archive_path = tmpdir.path().join(&asset.name);
+    fs::write(&archive_path, &archive_bytes)
+        .with_context(|| format!("failed to write {}", archive_path.display()))?;
+    let extracted = extract_binary(&archive_path, &tmpdir.path().join("extract"), BIN_NAME)?;
+    let current_exe = std::env::current_exe().context("failed to resolve current executable")?;
+    install_binary(&extracted, &current_exe)?;
+
+    println!(
+        "Updated wakezilla to v{release_version} at {}.",
+        current_exe.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release_json(tag: &str, target: &str, prerelease: bool) -> GitHubRelease {
+        let version = normalize_tag(tag);
+        GitHubRelease {
+            tag_name: tag.to_string(),
+            prerelease,
+            assets: vec![GitHubAsset {
+                name: asset_name(version, target),
+                browser_download_url: format!(
+                    "https://example.test/{}",
+                    asset_name(version, target)
+                ),
+            }],
+        }
+    }
+
+    #[test]
+    fn update_normalizes_tag_names() {
+        assert_eq!(normalize_tag("v0.2.3"), "0.2.3");
+        assert_eq!(normalize_tag("wakezilla/v0.2.3"), "0.2.3");
+        assert_eq!(normalize_tag("0.2.3"), "0.2.3");
+    }
+
+    #[test]
+    fn update_builds_release_urls() {
+        assert_eq!(
+            release_api_url(None),
+            "https://api.github.com/repos/guibeira/wakezilla/releases/latest"
+        );
+        assert_eq!(
+            release_api_url(Some("0.2.3")),
+            "https://api.github.com/repos/guibeira/wakezilla/releases/tags/v0.2.3"
+        );
+        assert_eq!(
+            release_api_url(Some("v0.2.3")),
+            "https://api.github.com/repos/guibeira/wakezilla/releases/tags/v0.2.3"
+        );
+        assert_eq!(
+            checksum_url("0.2.3"),
+            "https://github.com/guibeira/wakezilla/releases/download/v0.2.3/SHA256SUMS"
+        );
+    }
+
+    #[test]
+    fn update_selects_release_asset_for_target() {
+        let release = release_json("v0.2.3", "x86_64-unknown-linux-gnu", false);
+        let asset = select_asset(&release, "x86_64-unknown-linux-gnu").expect("asset exists");
+
+        assert_eq!(
+            asset.name,
+            "wakezilla-0.2.3-x86_64-unknown-linux-gnu.tar.gz"
+        );
+        assert_eq!(
+            asset.browser_download_url,
+            "https://example.test/wakezilla-0.2.3-x86_64-unknown-linux-gnu.tar.gz"
+        );
+    }
+
+    #[test]
+    fn update_missing_asset_reports_available_targets() {
+        let release = release_json("v0.2.3", "x86_64-apple-darwin", false);
+        let error = select_asset(&release, "x86_64-unknown-linux-gnu")
+            .expect_err("target should be missing")
+            .to_string();
+
+        assert!(error.contains("x86_64-unknown-linux-gnu"));
+        assert!(error.contains("x86_64-apple-darwin"));
+    }
+
+    #[test]
+    fn update_detects_targets_from_parts() {
+        assert_eq!(
+            target_from_parts("linux", "x86_64", Some("gnu")).unwrap(),
+            "x86_64-unknown-linux-gnu"
+        );
+        assert_eq!(
+            target_from_parts("linux", "arm64", Some("musl")).unwrap(),
+            "aarch64-unknown-linux-musl"
+        );
+        assert_eq!(
+            target_from_parts("darwin", "arm64", None).unwrap(),
+            "aarch64-apple-darwin"
+        );
+    }
+
+    #[test]
+    fn update_status_reports_available_release() {
+        let release = release_json("v0.2.3", "x86_64-unknown-linux-gnu", false);
+        assert_eq!(
+            status_from_release("0.2.2", &release).unwrap(),
+            UpdateStatus::Available {
+                current: "0.2.2".to_string(),
+                latest: "0.2.3".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn update_status_reports_current_release() {
+        let release = release_json("v0.2.2", "x86_64-unknown-linux-gnu", false);
+        assert_eq!(
+            status_from_release("0.2.2", &release).unwrap(),
+            UpdateStatus::Current {
+                current: "0.2.2".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn update_status_ignores_prerelease_for_startup_check() {
+        let release = release_json("v0.2.3-rc1", "x86_64-unknown-linux-gnu", true);
+        assert_eq!(
+            status_from_release("0.2.2", &release).unwrap(),
+            UpdateStatus::Current {
+                current: "0.2.2".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn update_checksum_passes_for_matching_hash() {
+        let bytes = b"wakezilla";
+        let hash = sha256_hex(bytes);
+        let checksums = format!("{hash}  wakezilla-0.2.3-x86_64-unknown-linux-gnu.tar.gz\n");
+
+        verify_checksum_bytes(
+            bytes,
+            &checksums,
+            "wakezilla-0.2.3-x86_64-unknown-linux-gnu.tar.gz",
+        )
+        .expect("checksum should match");
+    }
+
+    #[test]
+    fn update_checksum_fails_for_mismatched_hash() {
+        let error = verify_checksum_bytes(
+            b"wakezilla",
+            "000000  wakezilla-0.2.3-x86_64-unknown-linux-gnu.tar.gz\n",
+            "wakezilla-0.2.3-x86_64-unknown-linux-gnu.tar.gz",
+        )
+        .expect_err("checksum should fail")
+        .to_string();
+
+        assert!(error.contains("checksum verification failed"));
+    }
+
+    #[test]
+    fn update_extracts_binary_from_archive_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive_path = dir.path().join("wakezilla.tar.gz");
+        let archive_file = fs::File::create(&archive_path).expect("archive file");
+        let encoder = flate2::write::GzEncoder::new(archive_file, flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        let body = b"#!/bin/sh\n";
+        header.set_path(BIN_NAME).expect("header path");
+        header.set_size(body.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder
+            .append(&header, &body[..])
+            .expect("append binary to tar");
+        let encoder = builder.into_inner().expect("finish tar");
+        encoder.finish().expect("finish gzip");
+
+        let extracted =
+            extract_binary(&archive_path, &dir.path().join("extract"), BIN_NAME).expect("extract");
+        assert_eq!(
+            fs::read_to_string(extracted).expect("read binary"),
+            "#!/bin/sh\n"
+        );
+    }
+
+    #[test]
+    fn update_installs_binary_to_destination() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("wakezilla.new");
+        let dst = dir.path().join("wakezilla");
+        fs::write(&src, b"new").expect("write src");
+        fs::write(&dst, b"old").expect("write dst");
+
+        install_binary(&src, &dst).expect("install");
+
+        assert_eq!(fs::read(&dst).expect("read dst"), b"new");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&dst).expect("metadata").permissions().mode() & 0o777,
+                0o755
+            );
+        }
+    }
+}

--- a/tests/setup_tests.rs
+++ b/tests/setup_tests.rs
@@ -16,9 +16,21 @@ fn mode_exposes_subcommand_and_service_name() {
 }
 
 #[test]
+fn service_program_args_disable_update_checks() {
+    assert_eq!(
+        service::service_program_args(Mode::Proxy),
+        ["--no-update-check", "proxy-server"]
+    );
+    assert_eq!(
+        service::service_program_args(Mode::Client),
+        ["--no-update-check", "client-server"]
+    );
+}
+
+#[test]
 fn systemd_unit_contains_exec_start_with_exe_and_subcommand() {
     let unit = service::generate_systemd_unit(Mode::Proxy, "/usr/local/bin/wakezilla");
-    assert!(unit.contains("ExecStart=/usr/local/bin/wakezilla proxy-server"));
+    assert!(unit.contains("ExecStart=/usr/local/bin/wakezilla --no-update-check proxy-server"));
     assert!(unit.contains("[Service]"));
     assert!(unit.contains("WantedBy=multi-user.target"));
 }
@@ -28,7 +40,8 @@ fn launchd_plist_contains_label_exe_and_subcommand() {
     let plist = service::generate_launchd_plist(Mode::Client, "/usr/local/bin/wakezilla");
     assert!(plist.contains("dev.wakezilla.client"));
     assert!(plist.contains("/usr/local/bin/wakezilla"));
-    assert!(plist.contains("client-server"));
+    assert!(plist.contains("<string>--no-update-check</string>"));
+    assert!(plist.contains("<string>client-server</string>"));
     assert!(plist.contains("<key>RunAtLoad</key>"));
     assert!(plist.contains("<key>StandardErrorPath</key>"));
     assert!(plist.contains("<key>StandardOutPath</key>"));


### PR DESCRIPTION
## Summary
- add `wakezilla update` with optional `--version` support backed by GitHub Releases assets and SHA256 verification
- add automatic startup update checks plus a global `--no-update-check` escape hatch
- ensure setup-installed services always run with `--no-update-check` and document the new workflow

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `sh -n install.sh scripts/test-install-sh.sh && sh scripts/test-install-sh.sh`
- `cargo run -- --no-update-check update --help`
- `cargo run -- --no-update-check --version`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `update` command to manually update to the latest or specific version
  * Automatic update availability check now runs at startup (can be disabled with `--no-update-check` flag)
  * Service installations auto-configured to skip update checks for offline/scripted environments

* **Documentation**
  * Updated README with update instructions and `--no-update-check` usage guidance
  * Clarified that service upgrades require manual execution of `wakezilla update`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->