### PR TITLE
feat: per-service access history with usage chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 frontend-dist
 machines.json
 access_history.json
+docs/plans/
+docs/superpowers/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ frontend/target
 dist
 frontend-dist
 machines.json
+access_history.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3660,6 +3660,7 @@ dependencies = [
  "libc",
  "mio 1.0.4",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
  "socket2",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ include = [
 clap = { version = "4", features = ["derive"] }
 axum = { version = "0.7", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.38.0", features = ["rt-multi-thread", "macros", "sync", "net", "time", "io-util"] }
+tokio = { version = "1.38.0", features = ["rt-multi-thread", "macros", "sync", "net", "time", "io-util", "signal"] }
 serde_json = "1.0"
 askama = "0.12"
 askama_axum = "0.4"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -77,3 +77,16 @@ pub struct DiscoveredDevice {
     pub mac: String,
     pub hostname: Option<String>,
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ServiceAccessHistory {
+    pub name: Option<String>,
+    pub local_port: u16,
+    pub target_port: u16,
+    pub timestamps: Vec<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AccessHistory {
+    pub services: Vec<ServiceAccessHistory>,
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
   <link data-trunk rel="css" href="style/main.css">
   <link data-trunk rel="copy-dir" href="/public/images"/>
   <link rel="icon" data-trunk href="/favicon.ico" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 </head>
 
 <body></body>

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -1,4 +1,6 @@
-use crate::models::{AccessHistory, DiscoveredDevice, Machine, NetworkInterface, UpdateMachinePayload};
+use crate::models::{
+    AccessHistory, DiscoveredDevice, Machine, NetworkInterface, UpdateMachinePayload,
+};
 use std::sync::LazyLock;
 
 use leptos::leptos_dom::logging::console_log;
@@ -74,13 +76,17 @@ pub async fn get_details_machine(mac: &str) -> Result<Machine, String> {
 
 pub async fn get_access_history(mac: &str) -> Result<AccessHistory, String> {
     let mac = encode_path_segment(mac);
-    Request::get(&format!("{}/machines/{}/access-history", API_BASE.as_str(), mac))
-        .send()
-        .await
-        .map_err(|e| e.to_string())?
-        .json()
-        .await
-        .map_err(|e| e.to_string())
+    Request::get(&format!(
+        "{}/machines/{}/access-history",
+        API_BASE.as_str(),
+        mac
+    ))
+    .send()
+    .await
+    .map_err(|e| e.to_string())?
+    .json()
+    .await
+    .map_err(|e| e.to_string())
 }
 
 pub async fn update_machine(mac: &str, payload: &UpdateMachinePayload) -> Result<(), String> {

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -1,4 +1,4 @@
-use crate::models::{DiscoveredDevice, Machine, NetworkInterface, UpdateMachinePayload};
+use crate::models::{AccessHistory, DiscoveredDevice, Machine, NetworkInterface, UpdateMachinePayload};
 use std::sync::LazyLock;
 
 use leptos::leptos_dom::logging::console_log;
@@ -64,6 +64,17 @@ pub async fn create_machine(machine: Machine) -> Result<(), String> {
 pub async fn get_details_machine(mac: &str) -> Result<Machine, String> {
     let mac = encode_path_segment(mac);
     Request::get(&format!("{}/machines/{}", API_BASE.as_str(), mac))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .json()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+pub async fn get_access_history(mac: &str) -> Result<AccessHistory, String> {
+    let mac = encode_path_segment(mac);
+    Request::get(&format!("{}/machines/{}/access-history", API_BASE.as_str(), mac))
         .send()
         .await
         .map_err(|e| e.to_string())?

--- a/frontend/src/components/machines/detail.rs
+++ b/frontend/src/components/machines/detail.rs
@@ -107,13 +107,18 @@ pub fn MachineDetailPage() -> impl IntoView {
     });
 
     let (access_history, set_access_history) = signal::<Option<AccessHistory>>(None);
+    let (history_refresh, set_history_refresh) = signal(0u32);
+    let (history_loading, set_history_loading) = signal(false);
 
     Effect::new(move || {
         let mac_val = mac();
+        history_refresh.get(); // re-run when the refresh button is pressed
+        set_history_loading.set(true);
         leptos::task::spawn_local(async move {
             if let Ok(h) = get_access_history(&mac_val).await {
                 set_access_history.set(Some(h));
             }
+            set_history_loading.set(false);
         });
     });
 
@@ -716,6 +721,14 @@ pub fn MachineDetailPage() -> impl IntoView {
                         on:click=move |_| set_by_hour.set(true)
                     >
                         "By hour"
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-soft btn-sm"
+                        disabled=move || history_loading.get()
+                        on:click=move |_| set_history_refresh.update(|n| *n += 1)
+                    >
+                        {move || if history_loading.get() { "Refreshing..." } else { "Refresh" }}
                     </button>
                 </div>
                 <canvas id="usage-chart"></canvas>

--- a/frontend/src/components/machines/detail.rs
+++ b/frontend/src/components/machines/detail.rs
@@ -11,6 +11,77 @@ use web_sys::SubmitEvent;
 use crate::api::{get_details_machine, turn_off_machine, wake_machine};
 use crate::models::{Machine, PortForward, UpdateMachinePayload};
 
+use wasm_bindgen::prelude::*;
+use chrono::{DateTime, TimeZone, Utc};
+use crate::api::get_access_history;
+use crate::models::AccessHistory;
+
+#[wasm_bindgen(inline_js = r#"
+export function render_usage_chart(canvas_id, labels_json, datasets_json) {
+    if (typeof window.Chart === 'undefined') { return; }
+    const el = document.getElementById(canvas_id);
+    if (!el) { return; }
+    const labels = JSON.parse(labels_json);
+    const datasets = JSON.parse(datasets_json);
+    const palette = ['#2563eb','#16a34a','#dc2626','#d97706','#7c3aed','#0891b2','#db2777'];
+    datasets.forEach((d, i) => {
+        d.backgroundColor = palette[i % palette.length];
+        d.borderColor = palette[i % palette.length];
+    });
+    if (el._chart) { el._chart.destroy(); }
+    el._chart = new window.Chart(el, {
+        type: 'bar',
+        data: { labels: labels, datasets: datasets },
+        options: {
+            responsive: true,
+            scales: { y: { beginAtZero: true, ticks: { precision: 0 } } },
+            plugins: { legend: { position: 'bottom' } }
+        }
+    });
+}
+"#)]
+extern "C" {
+    fn render_usage_chart(canvas_id: &str, labels_json: &str, datasets_json: &str);
+}
+
+// Returns (sorted day labels "YYYY-MM-DD", per-service datasets as JSON values with counts aligned to labels)
+fn bucket_by_day(history: &AccessHistory) -> (Vec<String>, Vec<serde_json::Value>) {
+    use std::collections::{BTreeSet, HashMap};
+
+    let day_of = |ts: i64| -> String {
+        let dt: DateTime<Utc> = Utc.timestamp_millis_opt(ts).single().unwrap_or_else(Utc::now);
+        dt.format("%Y-%m-%d").to_string()
+    };
+
+    let mut all_days: BTreeSet<String> = BTreeSet::new();
+    let mut per_service: Vec<(String, HashMap<String, u32>)> = Vec::new();
+
+    for svc in &history.services {
+        let label = svc
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("port {}", svc.local_port));
+        let mut counts: HashMap<String, u32> = HashMap::new();
+        for &ts in &svc.timestamps {
+            let day = day_of(ts);
+            all_days.insert(day.clone());
+            *counts.entry(day).or_insert(0) += 1;
+        }
+        per_service.push((label, counts));
+    }
+
+    let labels: Vec<String> = all_days.into_iter().collect();
+    let datasets: Vec<serde_json::Value> = per_service
+        .into_iter()
+        .map(|(label, counts)| {
+            let data: Vec<u32> = labels.iter().map(|d| *counts.get(d).unwrap_or(&0)).collect();
+            serde_json::json!({ "label": label, "data": data })
+        })
+        .collect();
+
+    (labels, datasets)
+}
+
 #[component]
 pub fn MachineDetailPage() -> impl IntoView {
     let params = use_params_map();
@@ -25,6 +96,26 @@ pub fn MachineDetailPage() -> impl IntoView {
                 set_machine_details.set(cats);
             }
         });
+    });
+
+    let (access_history, set_access_history) = signal::<Option<AccessHistory>>(None);
+
+    Effect::new(move || {
+        let mac_val = mac();
+        leptos::task::spawn_local(async move {
+            if let Ok(h) = get_access_history(&mac_val).await {
+                set_access_history.set(Some(h));
+            }
+        });
+    });
+
+    Effect::new(move || {
+        if let Some(history) = access_history.get() {
+            let (labels, datasets) = bucket_by_day(&history);
+            let labels_json = serde_json::to_string(&labels).unwrap_or_else(|_| "[]".into());
+            let datasets_json = serde_json::to_string(&datasets).unwrap_or_else(|_| "[]".into());
+            render_usage_chart("usage-chart", &labels_json, &datasets_json);
+        }
     });
 
     // Form state
@@ -584,6 +675,14 @@ pub fn MachineDetailPage() -> impl IntoView {
                         "Configure a remote shutdown port on the machine to activate this action."
                     </p>
                 </Show>
+            </div>
+
+            <div class="card">
+                <header class="card-header">
+                    <h3 class="card-title">"Access history"</h3>
+                    <p class="card-subtitle">"Connections per service, by day."</p>
+                </header>
+                <canvas id="usage-chart"></canvas>
             </div>
 
             <div class="card">

--- a/frontend/src/components/machines/detail.rs
+++ b/frontend/src/components/machines/detail.rs
@@ -11,10 +11,10 @@ use web_sys::SubmitEvent;
 use crate::api::{get_details_machine, turn_off_machine, wake_machine};
 use crate::models::{Machine, PortForward, UpdateMachinePayload};
 
-use wasm_bindgen::prelude::*;
-use chrono::{DateTime, TimeZone, Utc};
 use crate::api::get_access_history;
 use crate::models::AccessHistory;
+use chrono::{DateTime, TimeZone, Utc};
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(inline_js = r#"
 export function render_usage_chart(canvas_id, labels_json, datasets_json) {
@@ -49,7 +49,10 @@ fn bucket_by_day(history: &AccessHistory) -> (Vec<String>, Vec<serde_json::Value
     use std::collections::{BTreeSet, HashMap};
 
     let day_of = |ts: i64| -> String {
-        let dt: DateTime<Utc> = Utc.timestamp_millis_opt(ts).single().unwrap_or_else(Utc::now);
+        let dt: DateTime<Utc> = Utc
+            .timestamp_millis_opt(ts)
+            .single()
+            .unwrap_or_else(Utc::now);
         dt.format("%Y-%m-%d").to_string()
     };
 
@@ -74,7 +77,10 @@ fn bucket_by_day(history: &AccessHistory) -> (Vec<String>, Vec<serde_json::Value
     let datasets: Vec<serde_json::Value> = per_service
         .into_iter()
         .map(|(label, counts)| {
-            let data: Vec<u32> = labels.iter().map(|d| *counts.get(d).unwrap_or(&0)).collect();
+            let data: Vec<u32> = labels
+                .iter()
+                .map(|d| *counts.get(d).unwrap_or(&0))
+                .collect();
             serde_json::json!({ "label": label, "data": data })
         })
         .collect();

--- a/frontend/src/components/machines/detail.rs
+++ b/frontend/src/components/machines/detail.rs
@@ -44,19 +44,21 @@ extern "C" {
     fn render_usage_chart(canvas_id: &str, labels_json: &str, datasets_json: &str);
 }
 
-// Returns (sorted day labels "YYYY-MM-DD", per-service datasets as JSON values with counts aligned to labels)
-fn bucket_by_day(history: &AccessHistory) -> (Vec<String>, Vec<serde_json::Value>) {
+// Buckets timestamps using the given chrono format (e.g. "%Y-%m-%d" for day,
+// "%Y-%m-%d %H:00" for hour). Returns (sorted bucket labels, per-service datasets
+// as JSON values with counts aligned to labels).
+fn bucket_history(history: &AccessHistory, fmt: &str) -> (Vec<String>, Vec<serde_json::Value>) {
     use std::collections::{BTreeSet, HashMap};
 
-    let day_of = |ts: i64| -> String {
+    let bucket_of = |ts: i64| -> String {
         let dt: DateTime<Utc> = Utc
             .timestamp_millis_opt(ts)
             .single()
             .unwrap_or_else(Utc::now);
-        dt.format("%Y-%m-%d").to_string()
+        dt.format(fmt).to_string()
     };
 
-    let mut all_days: BTreeSet<String> = BTreeSet::new();
+    let mut all_buckets: BTreeSet<String> = BTreeSet::new();
     let mut per_service: Vec<(String, HashMap<String, u32>)> = Vec::new();
 
     for svc in &history.services {
@@ -66,14 +68,14 @@ fn bucket_by_day(history: &AccessHistory) -> (Vec<String>, Vec<serde_json::Value
             .unwrap_or_else(|| format!("port {}", svc.local_port));
         let mut counts: HashMap<String, u32> = HashMap::new();
         for &ts in &svc.timestamps {
-            let day = day_of(ts);
-            all_days.insert(day.clone());
-            *counts.entry(day).or_insert(0) += 1;
+            let bucket = bucket_of(ts);
+            all_buckets.insert(bucket.clone());
+            *counts.entry(bucket).or_insert(0) += 1;
         }
         per_service.push((label, counts));
     }
 
-    let labels: Vec<String> = all_days.into_iter().collect();
+    let labels: Vec<String> = all_buckets.into_iter().collect();
     let datasets: Vec<serde_json::Value> = per_service
         .into_iter()
         .map(|(label, counts)| {
@@ -115,9 +117,17 @@ pub fn MachineDetailPage() -> impl IntoView {
         });
     });
 
+    // false = bucket by day, true = bucket by hour
+    let (by_hour, set_by_hour) = signal(false);
+
     Effect::new(move || {
         if let Some(history) = access_history.get() {
-            let (labels, datasets) = bucket_by_day(&history);
+            let fmt = if by_hour.get() {
+                "%Y-%m-%d %H:00"
+            } else {
+                "%Y-%m-%d"
+            };
+            let (labels, datasets) = bucket_history(&history, fmt);
             let labels_json = serde_json::to_string(&labels).unwrap_or_else(|_| "[]".into());
             let datasets_json = serde_json::to_string(&datasets).unwrap_or_else(|_| "[]".into());
             render_usage_chart("usage-chart", &labels_json, &datasets_json);
@@ -686,8 +696,28 @@ pub fn MachineDetailPage() -> impl IntoView {
             <div class="card">
                 <header class="card-header">
                     <h3 class="card-title">"Access history"</h3>
-                    <p class="card-subtitle">"Connections per service, by day."</p>
+                    <p class="card-subtitle">"Connections per service over time."</p>
                 </header>
+                <div class="actions-row">
+                    <button
+                        type="button"
+                        class=move || {
+                            if by_hour.get() { "btn btn-soft btn-sm" } else { "btn btn-primary btn-sm" }
+                        }
+                        on:click=move |_| set_by_hour.set(false)
+                    >
+                        "By day"
+                    </button>
+                    <button
+                        type="button"
+                        class=move || {
+                            if by_hour.get() { "btn btn-primary btn-sm" } else { "btn btn-soft btn-sm" }
+                        }
+                        on:click=move |_| set_by_hour.set(true)
+                    >
+                        "By hour"
+                    </button>
+                </div>
                 <canvas id="usage-chart"></canvas>
             </div>
 

--- a/frontend/src/models.rs
+++ b/frontend/src/models.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 pub use wakezilla_common::{
-    AccessHistory, DiscoveredDevice, Machine, NetworkInterface, PortForward,
-    ServiceAccessHistory, UpdateMachinePayload,
+    AccessHistory, DiscoveredDevice, Machine, NetworkInterface, PortForward, ServiceAccessHistory,
+    UpdateMachinePayload,
 };
 
 pub fn validate_machine_form(machine: &Machine) -> HashMap<String, Vec<String>> {

--- a/frontend/src/models.rs
+++ b/frontend/src/models.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 pub use wakezilla_common::{
-    DiscoveredDevice, Machine, NetworkInterface, PortForward, UpdateMachinePayload,
+    AccessHistory, DiscoveredDevice, Machine, NetworkInterface, PortForward,
+    ServiceAccessHistory, UpdateMachinePayload,
 };
 
 pub fn validate_machine_form(machine: &Machine) -> HashMap<String, Vec<String>> {

--- a/src/access_log.rs
+++ b/src/access_log.rs
@@ -1,0 +1,123 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::info;
+
+const MAX_RECORDS_PER_SERVICE: usize = 1000;
+const DEFAULT_HISTORY_PATH: &str = "access_history.json";
+
+pub fn service_key(mac: &str, local_port: u16) -> String {
+    format!("{}-{}", mac, local_port)
+}
+
+pub fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+pub fn access_log_path() -> PathBuf {
+    let path = if let Ok(p) = env::var("WAKEZILLA__STORAGE__ACCESS_HISTORY_PATH") {
+        PathBuf::from(p)
+    } else {
+        env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(DEFAULT_HISTORY_PATH)
+    };
+    if path.is_absolute() {
+        path
+    } else {
+        env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct AccessLog {
+    #[serde(flatten)]
+    inner: HashMap<String, VecDeque<i64>>,
+}
+
+impl AccessLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record(&mut self, key: &str, ts: i64) {
+        let buf = self.inner.entry(key.to_string()).or_default();
+        buf.push_back(ts);
+        while buf.len() > MAX_RECORDS_PER_SERVICE {
+            buf.pop_front();
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Vec<i64> {
+        self.inner
+            .get(key)
+            .map(|b| b.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn load() -> Self {
+        let path = access_log_path();
+        match fs::read_to_string(&path) {
+            Ok(data) => serde_json::from_str(&data).unwrap_or_else(|e| {
+                tracing::warn!("Failed to parse access history at {}: {e}", path.display());
+                Self::new()
+            }),
+            Err(_) => Self::new(),
+        }
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = access_log_path();
+        let data = serde_json::to_string(self).context("Failed to serialize access history")?;
+        fs::write(&path, data)
+            .with_context(|| format!("Failed to write access history to {}", path.display()))?;
+        info!("Saved access history to {}", path.display());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_appends_timestamps() {
+        let mut log = AccessLog::new();
+        log.record("aa-80", 1);
+        log.record("aa-80", 2);
+        assert_eq!(log.get("aa-80"), vec![1, 2]);
+    }
+
+    #[test]
+    fn record_caps_at_1000_dropping_oldest() {
+        let mut log = AccessLog::new();
+        for i in 0..1100 {
+            log.record("aa-80", i);
+        }
+        let got = log.get("aa-80");
+        assert_eq!(got.len(), 1000);
+        assert_eq!(got.first(), Some(&100));
+        assert_eq!(got.last(), Some(&1099));
+    }
+
+    #[test]
+    fn get_missing_key_is_empty() {
+        let log = AccessLog::new();
+        assert!(log.get("nope").is_empty());
+    }
+
+    #[test]
+    fn service_key_format() {
+        assert_eq!(service_key("AA:BB", 1234), "AA:BB-1234");
+    }
+}

--- a/src/access_log.rs
+++ b/src/access_log.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
 
-const DEFAULT_MAX_RECORDS_PER_SERVICE: usize = 2000;
 const DEFAULT_HISTORY_PATH: &str = "access_history.json";
 
 pub fn service_key(mac: &str, local_port: u16) -> String {
@@ -56,14 +55,12 @@ impl AccessLog {
     }
 
     pub fn record(&mut self, key: &str, ts: i64) {
-        let cap = if self.max_records == 0 {
-            DEFAULT_MAX_RECORDS_PER_SERVICE
-        } else {
-            self.max_records
-        };
+        if self.max_records == 0 {
+            return;
+        }
         let buf = self.inner.entry(key.to_string()).or_default();
         buf.push_back(ts);
-        while buf.len() > cap {
+        while buf.len() > self.max_records {
             buf.pop_front();
         }
     }
@@ -137,6 +134,14 @@ mod tests {
     fn get_missing_key_is_empty() {
         let log = AccessLog::new(2000);
         assert!(log.get("nope").is_empty());
+    }
+
+    #[test]
+    fn record_disabled_when_cap_zero() {
+        let mut log = AccessLog::new(0);
+        log.record("k", 1);
+        log.record("k", 2);
+        assert!(log.get("k").is_empty());
     }
 
     #[test]

--- a/src/access_log.rs
+++ b/src/access_log.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tracing::info;
+use tracing::debug;
 
 const MAX_RECORDS_PER_SERVICE: usize = 1000;
 const DEFAULT_HISTORY_PATH: &str = "access_history.json";
@@ -81,7 +81,7 @@ impl AccessLog {
         let data = serde_json::to_string(self).context("Failed to serialize access history")?;
         fs::write(&path, data)
             .with_context(|| format!("Failed to write access history to {}", path.display()))?;
-        info!("Saved access history to {}", path.display());
+        debug!("Saved access history to {}", path.display());
         Ok(())
     }
 }

--- a/src/access_log.rs
+++ b/src/access_log.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
 
-const MAX_RECORDS_PER_SERVICE: usize = 1000;
+const DEFAULT_MAX_RECORDS_PER_SERVICE: usize = 2000;
 const DEFAULT_HISTORY_PATH: &str = "access_history.json";
 
 pub fn service_key(mac: &str, local_port: u16) -> String {
@@ -39,21 +39,31 @@ pub fn access_log_path() -> PathBuf {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccessLog {
     #[serde(flatten)]
     inner: HashMap<String, VecDeque<i64>>,
+    #[serde(skip)]
+    max_records: usize,
 }
 
 impl AccessLog {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(max_records: usize) -> Self {
+        Self {
+            inner: HashMap::new(),
+            max_records,
+        }
     }
 
     pub fn record(&mut self, key: &str, ts: i64) {
+        let cap = if self.max_records == 0 {
+            DEFAULT_MAX_RECORDS_PER_SERVICE
+        } else {
+            self.max_records
+        };
         let buf = self.inner.entry(key.to_string()).or_default();
         buf.push_back(ts);
-        while buf.len() > MAX_RECORDS_PER_SERVICE {
+        while buf.len() > cap {
             buf.pop_front();
         }
     }
@@ -65,15 +75,17 @@ impl AccessLog {
             .unwrap_or_default()
     }
 
-    pub fn load() -> Self {
+    pub fn load(max_records: usize) -> Self {
         let path = access_log_path();
-        match fs::read_to_string(&path) {
+        let mut log = match fs::read_to_string(&path) {
             Ok(data) => serde_json::from_str(&data).unwrap_or_else(|e| {
                 tracing::warn!("Failed to parse access history at {}: {e}", path.display());
-                Self::new()
+                Self::new(max_records)
             }),
-            Err(_) => Self::new(),
-        }
+            Err(_) => Self::new(max_records),
+        };
+        log.max_records = max_records;
+        log
     }
 
     pub fn save(&self) -> Result<()> {
@@ -92,7 +104,7 @@ mod tests {
 
     #[test]
     fn record_appends_timestamps() {
-        let mut log = AccessLog::new();
+        let mut log = AccessLog::new(2000);
         log.record("aa-80", 1);
         log.record("aa-80", 2);
         assert_eq!(log.get("aa-80"), vec![1, 2]);
@@ -100,7 +112,7 @@ mod tests {
 
     #[test]
     fn record_caps_at_1000_dropping_oldest() {
-        let mut log = AccessLog::new();
+        let mut log = AccessLog::new(1000);
         for i in 0..1100 {
             log.record("aa-80", i);
         }
@@ -111,8 +123,19 @@ mod tests {
     }
 
     #[test]
+    fn record_respects_configured_cap() {
+        let mut log = AccessLog::new(3);
+        for i in 0..10 {
+            log.record("k", i);
+        }
+        let got = log.get("k");
+        assert_eq!(got.len(), 3);
+        assert_eq!(got, vec![7, 8, 9]);
+    }
+
+    #[test]
     fn get_missing_key_is_empty() {
-        let log = AccessLog::new();
+        let log = AccessLog::new(2000);
         assert!(log.get("nope").is_empty());
     }
 

--- a/src/api_models.rs
+++ b/src/api_models.rs
@@ -1,4 +1,4 @@
 pub use wakezilla_common::{
-    AddMachinePayload, DeleteMachinePayload, DiscoveredDevice, Machine, NetworkInterface,
-    PortForward, UpdateMachinePayload,
+    AccessHistory, AddMachinePayload, DeleteMachinePayload, DiscoveredDevice, Machine,
+    NetworkInterface, PortForward, ServiceAccessHistory, UpdateMachinePayload,
 };

--- a/src/config.rs
+++ b/src/config.rs
@@ -215,12 +215,17 @@ pub struct StorageConfig {
     /// Path to the machines database file (default: "machines.json")
     #[serde(default = "default_machines_db_path")]
     pub machines_db_path: String,
+
+    /// Maximum access-history records kept per service (default: 2000)
+    #[serde(default = "default_max_access_records")]
+    pub max_access_records: usize,
 }
 
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
             machines_db_path: default_machines_db_path(),
+            max_access_records: default_max_access_records(),
         }
     }
 }
@@ -301,6 +306,9 @@ fn default_network_read_timeout_secs() -> u64 {
 }
 fn default_machines_db_path() -> String {
     DEFAULT_MACHINES_DB_PATH.into()
+}
+fn default_max_access_records() -> usize {
+    2000
 }
 fn default_health_check_interval_ms() -> u64 {
     30000

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -155,8 +155,8 @@ impl TurnOffLimiter {
         mut rx: watch::Receiver<bool>,
         config: Arc<Config>,
         access_log: Arc<RwLock<AccessLog>>,
-        service_key: String,
     ) -> Result<()> {
+        let service_key = crate::access_log::service_key(&machine.mac, local_port);
         let listen_addr = format!("0.0.0.0:{}", local_port);
         let listener = TcpListener::bind(&listen_addr)
             .await
@@ -311,7 +311,6 @@ impl TurnOffLimiter {
         limiter: Arc<TurnOffLimiter>,
         config: Arc<Config>,
         access_log: Arc<RwLock<AccessLog>>,
-        service_key: String,
     ) -> Result<()> {
         // Initialize machine configuration if turn-off is enabled
         if machine.can_be_turned_off {
@@ -335,7 +334,7 @@ impl TurnOffLimiter {
         }
 
         limiter
-            .proxy_internal(local_port, remote_addr, machine, rx, config, access_log, service_key)
+            .proxy_internal(local_port, remote_addr, machine, rx, config, access_log)
             .await
     }
 }

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -1,3 +1,4 @@
+use crate::access_log::{now_millis, AccessLog};
 use crate::{config::Config, web::Machine, wol};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
@@ -8,6 +9,7 @@ use std::time::Duration;
 use tokio::io::copy_bidirectional;
 use tokio::net::TcpListener;
 use tokio::sync::watch;
+use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
 
@@ -152,6 +154,8 @@ impl TurnOffLimiter {
         machine: Machine,
         mut rx: watch::Receiver<bool>,
         config: Arc<Config>,
+        access_log: Arc<RwLock<AccessLog>>,
+        service_key: String,
     ) -> Result<()> {
         let listen_addr = format!("0.0.0.0:{}", local_port);
         let listener = TcpListener::bind(&listen_addr)
@@ -181,6 +185,11 @@ impl TurnOffLimiter {
                         "Accepted connection from {} to forward to {}",
                         client_addr, remote_addr
                     );
+
+                    access_log
+                        .write()
+                        .await
+                        .record(&service_key, now_millis());
 
                     let remote_addr_clone = remote_addr;
                     let mac_str_clone = machine.mac.clone();
@@ -301,6 +310,8 @@ impl TurnOffLimiter {
         rx: watch::Receiver<bool>,
         limiter: Arc<TurnOffLimiter>,
         config: Arc<Config>,
+        access_log: Arc<RwLock<AccessLog>>,
+        service_key: String,
     ) -> Result<()> {
         // Initialize machine configuration if turn-off is enabled
         if machine.can_be_turned_off {
@@ -324,7 +335,7 @@ impl TurnOffLimiter {
         }
 
         limiter
-            .proxy_internal(local_port, remote_addr, machine, rx, config)
+            .proxy_internal(local_port, remote_addr, machine, rx, config, access_log, service_key)
             .await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod access_log;
 pub mod api_models;
 pub mod client_server;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 use std::net::{IpAddr, Ipv4Addr};
 use tracing::{error, info, instrument};
 
+mod access_log;
 mod api_models;
 mod client_server;
 mod config;

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -102,13 +102,16 @@ pub async fn start(config: crate::config::Config) -> Result<()> {
         }
     };
 
+    let max_access_records = config.storage.max_access_records;
     let state = AppState {
         machines: Arc::new(RwLock::new(initial_machines.clone())),
         proxies: Arc::new(RwLock::new(HashMap::new())),
         config: Arc::new(config),
         turn_off_limiter: Arc::new(forward::TurnOffLimiter::new()),
         monitor_handle: Arc::new(std::sync::Mutex::new(None)),
-        access_log: Arc::new(RwLock::new(crate::access_log::AccessLog::load())),
+        access_log: Arc::new(RwLock::new(crate::access_log::AccessLog::load(
+            max_access_records,
+        ))),
     };
 
     // Start global monitor
@@ -639,13 +642,17 @@ mod tests {
     }
 
     fn state_with_machines(machines: Vec<Machine>) -> AppState {
+        let config = crate::config::Config::default();
+        let max_access_records = config.storage.max_access_records;
         let state = AppState {
             machines: Arc::new(RwLock::new(machines)),
             proxies: Arc::new(RwLock::new(HashMap::new())),
-            config: Arc::new(crate::config::Config::default()),
+            config: Arc::new(config),
             turn_off_limiter: Arc::new(forward::TurnOffLimiter::new()),
             monitor_handle: Arc::new(std::sync::Mutex::new(None)),
-            access_log: Arc::new(RwLock::new(crate::access_log::AccessLog::new())),
+            access_log: Arc::new(RwLock::new(crate::access_log::AccessLog::new(
+                max_access_records,
+            ))),
         };
         web::start_global_monitor(&state);
         state

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -121,9 +121,11 @@ pub async fn start(config: crate::config::Config) -> Result<()> {
             interval.tick().await; // consume the immediate first tick
             loop {
                 interval.tick().await;
-                let log = flush_state.access_log.read().await;
-                if let Err(e) = log.save() {
-                    error!("Failed to flush access history: {e}");
+                let snapshot = flush_state.access_log.read().await.clone();
+                match tokio::task::spawn_blocking(move || snapshot.save()).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => error!("Failed to flush access history: {e}"),
+                    Err(e) => error!("Access history flush task panicked: {e}"),
                 }
             }
         });

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -148,9 +148,42 @@ pub async fn start(config: crate::config::Config) -> Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = TcpListener::bind(addr).await?;
     info!("listening on http://{}", listener.local_addr()?);
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    // Persist access history on shutdown so the last interval isn't lost.
+    let snapshot = state.access_log.read().await.clone();
+    if let Err(e) = snapshot.save() {
+        error!("Failed to flush access history on shutdown: {e}");
+    }
 
     Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        if let Ok(mut sig) =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        {
+            sig.recv().await;
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    info!("Shutdown signal received");
 }
 
 pub fn api_routes(state: AppState) -> Router {

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -108,6 +108,7 @@ pub async fn start(config: crate::config::Config) -> Result<()> {
         config: Arc::new(config),
         turn_off_limiter: Arc::new(forward::TurnOffLimiter::new()),
         monitor_handle: Arc::new(std::sync::Mutex::new(None)),
+        access_log: Arc::new(RwLock::new(crate::access_log::AccessLog::load())),
     };
 
     // Start global monitor
@@ -585,6 +586,7 @@ mod tests {
             config: Arc::new(crate::config::Config::default()),
             turn_off_limiter: Arc::new(forward::TurnOffLimiter::new()),
             monitor_handle: Arc::new(std::sync::Mutex::new(None)),
+            access_log: Arc::new(RwLock::new(crate::access_log::AccessLog::new())),
         };
         web::start_global_monitor(&state);
         state

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -142,6 +142,10 @@ pub fn api_routes(state: AppState) -> Router {
             get(show_machines_api).post(add_machine_api),
         )
         .route("/api/machines/:mac", get(get_machine_details_api))
+        .route(
+            "/api/machines/:mac/access-history",
+            get(get_access_history_api),
+        )
         .route("/api/machines/:mac", put(update_machine_api))
         .route(
             "/api/machines/:mac/remote-turn-off",
@@ -326,6 +330,44 @@ async fn get_machine_details_api(
             Json(serde_json::json!({ "error": "Machine not found" })),
         ))
     }
+}
+
+async fn get_access_history_api(
+    State(state): State<AppState>,
+    Path(mac): Path<String>,
+) -> Result<Json<wakezilla_common::AccessHistory>, (axum::http::StatusCode, Json<serde_json::Value>)>
+{
+    let machines = state.machines.read().await;
+    let machine = machines.iter().find(|m| m.mac == mac).cloned();
+    drop(machines);
+
+    let Some(machine) = machine else {
+        return Err((
+            axum::http::StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "Machine not found" })),
+        ));
+    };
+
+    let log = state.access_log.read().await;
+    let services = machine
+        .port_forwards
+        .iter()
+        .map(|pf| {
+            let key = crate::access_log::service_key(&machine.mac, pf.local_port);
+            wakezilla_common::ServiceAccessHistory {
+                name: if pf.name.trim().is_empty() {
+                    None
+                } else {
+                    Some(pf.name.clone())
+                },
+                local_port: pf.local_port,
+                target_port: pf.target_port,
+                timestamps: log.get(&key),
+            }
+        })
+        .collect();
+
+    Ok(Json(wakezilla_common::AccessHistory { services }))
 }
 
 async fn update_machine_api(

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -114,6 +114,21 @@ pub async fn start(config: crate::config::Config) -> Result<()> {
     // Start global monitor
     web::start_global_monitor(&state);
 
+    {
+        let flush_state = state.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            interval.tick().await; // consume the immediate first tick
+            loop {
+                interval.tick().await;
+                let log = flush_state.access_log.read().await;
+                if let Err(e) = log.save() {
+                    error!("Failed to flush access history: {e}");
+                }
+            }
+        });
+    }
+
     for machine in &initial_machines {
         web::start_proxy_if_configured(machine, &state);
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -21,7 +21,9 @@ use ratatui::{
 };
 use reqwest::{Client, Response};
 use serde::Deserialize;
-use wakezilla_common::{DeleteMachinePayload, Machine};
+use wakezilla_common::{AccessHistory, DeleteMachinePayload, Machine};
+
+use crate::access_log::now_millis;
 
 const BASE: ratatui::style::Color = ratatui::style::Color::Rgb(30, 30, 46);
 const TEXT: ratatui::style::Color = ratatui::style::Color::Rgb(205, 214, 244);
@@ -76,6 +78,19 @@ impl ApiClient {
         json_response(response)
             .await
             .context("failed to decode /api/machines response")
+    }
+
+    async fn access_history(&self, mac: &str) -> Result<AccessHistory> {
+        let response = self
+            .http
+            .get(self.url(&format!("/api/machines/{mac}/access-history")))
+            .send()
+            .await
+            .with_context(|| format!("failed to request access history for {mac}"))?;
+
+        json_response(response)
+            .await
+            .with_context(|| format!("failed to decode access history for {mac}"))
     }
 
     async fn is_machine_on(&self, mac: &str) -> Result<bool> {
@@ -191,6 +206,7 @@ struct App {
     client: ApiClient,
     machines: Vec<Machine>,
     statuses: HashMap<String, Option<bool>>,
+    access_history: Option<AccessHistory>,
     selected: usize,
     loading: bool,
     should_quit: bool,
@@ -205,6 +221,7 @@ impl App {
             client,
             machines: Vec::new(),
             statuses: HashMap::new(),
+            access_history: None,
             selected: 0,
             loading: true,
             should_quit: false,
@@ -248,6 +265,14 @@ impl App {
             .filter(|message| message.created_at.elapsed() < Duration::from_secs(5))
     }
 
+    async fn load_selected_history(&mut self) {
+        let Some(mac) = self.selected_machine().map(|machine| machine.mac.clone()) else {
+            self.access_history = None;
+            return;
+        };
+        self.access_history = self.client.access_history(&mac).await.ok();
+    }
+
     async fn refresh(&mut self) {
         self.loading = true;
         match self.client.list_machines().await {
@@ -257,6 +282,7 @@ impl App {
                     self.selected = self.machines.len().saturating_sub(1);
                 }
                 self.statuses = self.client.statuses_for(&self.machines).await;
+                self.load_selected_history().await;
                 self.loading = false;
                 self.last_refresh = Instant::now();
                 self.set_message("Loaded machines", MessageLevel::Success);
@@ -379,8 +405,14 @@ async fn handle_key(app: &mut App, key: KeyEvent) {
 
     match key.code {
         KeyCode::Char('q') | KeyCode::Esc => app.should_quit = true,
-        KeyCode::Char('j') | KeyCode::Down => app.next(),
-        KeyCode::Char('k') | KeyCode::Up => app.previous(),
+        KeyCode::Char('j') | KeyCode::Down => {
+            app.next();
+            app.load_selected_history().await;
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            app.previous();
+            app.load_selected_history().await;
+        }
         KeyCode::Char('r') => app.refresh().await,
         KeyCode::Char('w') => app.wake_selected().await,
         KeyCode::Char('t') => app.turn_off_selected().await,
@@ -573,6 +605,13 @@ fn render_machine_detail(frame: &mut Frame, area: Rect, app: &App) {
     ];
     lines.extend(forwards);
 
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Access history (last 14 days)",
+        Style::default().fg(MAUVE).add_modifier(Modifier::BOLD),
+    )));
+    lines.extend(access_history_lines(app.access_history.as_ref()));
+
     let detail = Paragraph::new(lines).wrap(Wrap { trim: false }).block(
         Block::default()
             .borders(Borders::ALL)
@@ -586,6 +625,92 @@ fn render_machine_detail(frame: &mut Frame, area: Rect, app: &App) {
 
 fn label_style() -> Style {
     Style::default().fg(BLUE).add_modifier(Modifier::BOLD)
+}
+
+fn access_history_lines(history: Option<&AccessHistory>) -> Vec<Line<'static>> {
+    let Some(history) = history else {
+        return vec![Line::from(Span::styled(
+            "No data",
+            Style::default().fg(SUBTEXT),
+        ))];
+    };
+
+    if history.services.is_empty() {
+        return vec![Line::from(Span::styled(
+            "No access records",
+            Style::default().fg(SUBTEXT),
+        ))];
+    }
+
+    let mut lines = Vec::new();
+    for svc in &history.services {
+        let name = svc.name.clone().unwrap_or_else(|| "unnamed".to_string());
+        let total = svc.timestamps.len();
+        let last = svc
+            .timestamps
+            .iter()
+            .max()
+            .map(|&ts| relative_time(ts))
+            .unwrap_or_else(|| "never".to_string());
+
+        lines.push(Line::from(vec![
+            Span::styled(name, Style::default().fg(TEXT).add_modifier(Modifier::BOLD)),
+            Span::raw("  "),
+            Span::styled(format!("{total}×"), Style::default().fg(GREEN)),
+            Span::raw("  "),
+            Span::styled(format!("last {last}"), Style::default().fg(SUBTEXT)),
+        ]));
+        lines.push(Line::from(Span::styled(
+            format!("  {}", sparkline(&svc.timestamps, 14)),
+            Style::default().fg(BLUE),
+        )));
+    }
+    lines
+}
+
+fn relative_time(ts_millis: i64) -> String {
+    let diff = (now_millis() - ts_millis).max(0) / 1000;
+    if diff < 60 {
+        format!("{diff}s ago")
+    } else if diff < 3600 {
+        format!("{}m ago", diff / 60)
+    } else if diff < 86_400 {
+        format!("{}h ago", diff / 3600)
+    } else {
+        format!("{}d ago", diff / 86_400)
+    }
+}
+
+// Day-bucketed counts as unicode bars; today is the rightmost cell.
+fn sparkline(timestamps: &[i64], days: usize) -> String {
+    const BARS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    const MS_PER_DAY: i64 = 86_400_000;
+
+    let today = now_millis() / MS_PER_DAY;
+    let mut counts = vec![0u32; days];
+    for &ts in timestamps {
+        let offset = today - (ts / MS_PER_DAY);
+        if offset >= 0 && (offset as usize) < days {
+            counts[days - 1 - offset as usize] += 1;
+        }
+    }
+
+    let max = counts.iter().copied().max().unwrap_or(0);
+    if max == 0 {
+        return "·".repeat(days);
+    }
+
+    counts
+        .iter()
+        .map(|&c| {
+            if c == 0 {
+                ' '
+            } else {
+                let idx = ((c as usize * (BARS.len() - 1)) / max as usize).min(BARS.len() - 1);
+                BARS[idx]
+            }
+        })
+        .collect()
 }
 
 fn render_footer(frame: &mut Frame, area: Rect, app: &App) {

--- a/src/web.rs
+++ b/src/web.rs
@@ -224,6 +224,8 @@ pub fn start_proxy_if_configured(machine: &Machine, state: &AppState) {
 
         let proxies_clone = state.proxies.clone();
         let limiter_clone = state.turn_off_limiter.clone();
+        let access_log_clone = state.access_log.clone();
+        let svc_key = crate::access_log::service_key(&machine.mac, pf.local_port);
         tokio::spawn(async move {
             let mut proxies = proxies_clone.write().await;
             proxies.insert(proxy_key.clone(), tx);
@@ -238,6 +240,8 @@ pub fn start_proxy_if_configured(machine: &Machine, state: &AppState) {
                 rx,
                 limiter_clone,
                 config_clone,
+                access_log_clone,
+                svc_key,
             )
             .await
             {

--- a/src/web.rs
+++ b/src/web.rs
@@ -30,6 +30,7 @@ where
     Ipv4Addr::from_str(&s).map_err(serde::de::Error::custom)
 }
 
+use crate::access_log::AccessLog;
 use crate::config::Config;
 use crate::forward;
 
@@ -112,6 +113,7 @@ pub struct AppState {
     pub config: Arc<Config>,
     pub turn_off_limiter: Arc<forward::TurnOffLimiter>,
     pub monitor_handle: Arc<std::sync::Mutex<Option<tokio::task::AbortHandle>>>,
+    pub access_log: Arc<RwLock<AccessLog>>,
 }
 
 pub fn api_port_forward_to_internal(pf: &wakezilla_common::PortForward) -> PortForward {

--- a/src/web.rs
+++ b/src/web.rs
@@ -225,7 +225,6 @@ pub fn start_proxy_if_configured(machine: &Machine, state: &AppState) {
         let proxies_clone = state.proxies.clone();
         let limiter_clone = state.turn_off_limiter.clone();
         let access_log_clone = state.access_log.clone();
-        let svc_key = crate::access_log::service_key(&machine.mac, pf.local_port);
         tokio::spawn(async move {
             let mut proxies = proxies_clone.write().await;
             proxies.insert(proxy_key.clone(), tx);
@@ -241,7 +240,6 @@ pub fn start_proxy_if_configured(machine: &Machine, state: &AppState) {
                 limiter_clone,
                 config_clone,
                 access_log_clone,
-                svc_key,
             )
             .await
             {

--- a/tests/proxy_integration.rs
+++ b/tests/proxy_integration.rs
@@ -83,7 +83,7 @@ async fn proxy_forwards_tcp_traffic_and_can_shutdown() {
 
     let limiter = Arc::new(TurnOffLimiter::new());
     let config = Arc::new(Config::default());
-    let access_log = Arc::new(RwLock::new(AccessLog::default()));
+    let access_log = Arc::new(RwLock::new(AccessLog::new(2000)));
     let proxy_task = tokio::spawn(forward::TurnOffLimiter::proxy(
         local_port,
         remote_addr,

--- a/tests/proxy_integration.rs
+++ b/tests/proxy_integration.rs
@@ -7,6 +7,8 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 
 use std::sync::Arc;
+use tokio::sync::RwLock;
+use wakezilla::access_log::{self, AccessLog};
 use wakezilla::config::Config;
 use wakezilla::forward::{self, TurnOffLimiter};
 use wakezilla::web::Machine;
@@ -81,6 +83,8 @@ async fn proxy_forwards_tcp_traffic_and_can_shutdown() {
 
     let limiter = Arc::new(TurnOffLimiter::new());
     let config = Arc::new(Config::default());
+    let access_log = Arc::new(RwLock::new(AccessLog::default()));
+    let svc_key = access_log::service_key(&machine.mac, local_port);
     let proxy_task = tokio::spawn(forward::TurnOffLimiter::proxy(
         local_port,
         remote_addr,
@@ -88,6 +92,8 @@ async fn proxy_forwards_tcp_traffic_and_can_shutdown() {
         rx,
         limiter,
         config,
+        access_log,
+        svc_key,
     ));
 
     // Give the proxy a moment to bind its listener

--- a/tests/proxy_integration.rs
+++ b/tests/proxy_integration.rs
@@ -8,7 +8,7 @@ use tokio::sync::watch;
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use wakezilla::access_log::{self, AccessLog};
+use wakezilla::access_log::AccessLog;
 use wakezilla::config::Config;
 use wakezilla::forward::{self, TurnOffLimiter};
 use wakezilla::web::Machine;
@@ -84,7 +84,6 @@ async fn proxy_forwards_tcp_traffic_and_can_shutdown() {
     let limiter = Arc::new(TurnOffLimiter::new());
     let config = Arc::new(Config::default());
     let access_log = Arc::new(RwLock::new(AccessLog::default()));
-    let svc_key = access_log::service_key(&machine.mac, local_port);
     let proxy_task = tokio::spawn(forward::TurnOffLimiter::proxy(
         local_port,
         remote_addr,
@@ -93,7 +92,6 @@ async fn proxy_forwards_tcp_traffic_and_can_shutdown() {
         limiter,
         config,
         access_log,
-        svc_key,
     ));
 
     // Give the proxy a moment to bind its listener

--- a/tests/web_api_integration.rs
+++ b/tests/web_api_integration.rs
@@ -100,7 +100,12 @@ async fn access_history_returns_service_entries() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let parsed: wakezilla::AccessHistory = serde_json::from_slice(
-        &response.into_body().collect().await.expect("collect").to_bytes(),
+        &response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect")
+            .to_bytes(),
     )
     .expect("valid access history json");
     assert_eq!(parsed.services.len(), 1);

--- a/tests/web_api_integration.rs
+++ b/tests/web_api_integration.rs
@@ -47,7 +47,7 @@ fn setup_state(temp_dir: &TempDir) -> (AppState, EnvVarGuard) {
         config: Arc::new(config),
         turn_off_limiter: Arc::new(TurnOffLimiter::new()),
         monitor_handle: Arc::new(std::sync::Mutex::new(None)),
-        access_log: Arc::new(RwLock::new(wakezilla::access_log::AccessLog::new())),
+        access_log: Arc::new(RwLock::new(wakezilla::access_log::AccessLog::new(2000))),
     };
 
     (state, guard)

--- a/tests/web_api_integration.rs
+++ b/tests/web_api_integration.rs
@@ -67,6 +67,49 @@ fn sample_machine() -> InternalMachine {
 }
 
 #[tokio::test]
+async fn access_history_returns_service_entries() {
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let (state, _guard) = setup_state(&temp_dir);
+
+    let mut machine = sample_machine();
+    machine.port_forwards = vec![wakezilla::web::PortForward {
+        name: "konga".to_string(),
+        local_port: 1234,
+        target_port: 80,
+    }];
+    state.machines.write().await.push(machine.clone());
+
+    {
+        let key = wakezilla::access_log::service_key(&machine.mac, 1234);
+        let mut log = state.access_log.write().await;
+        log.record(&key, 1000);
+        log.record(&key, 2000);
+    }
+
+    let app = build_router(state.clone()).merge(api_routes(state.clone()));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/machines/AA:BB:CC:DD:EE:FF/access-history")
+                .method("GET")
+                .body(Body::empty())
+                .expect("failed to build request"),
+        )
+        .await
+        .expect("handler failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed: wakezilla::AccessHistory = serde_json::from_slice(
+        &response.into_body().collect().await.expect("collect").to_bytes(),
+    )
+    .expect("valid access history json");
+    assert_eq!(parsed.services.len(), 1);
+    assert_eq!(parsed.services[0].name.as_deref(), Some("konga"));
+    assert_eq!(parsed.services[0].local_port, 1234);
+    assert_eq!(parsed.services[0].timestamps, vec![1000, 2000]);
+}
+
+#[tokio::test]
 async fn add_machine_accepts_null_port_forward_name() {
     let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
     let (state, _guard) = setup_state(&temp_dir);

--- a/tests/web_api_integration.rs
+++ b/tests/web_api_integration.rs
@@ -47,6 +47,7 @@ fn setup_state(temp_dir: &TempDir) -> (AppState, EnvVarGuard) {
         config: Arc::new(config),
         turn_off_limiter: Arc::new(TurnOffLimiter::new()),
         monitor_handle: Arc::new(std::sync::Mutex::new(None)),
+        access_log: Arc::new(RwLock::new(wakezilla::access_log::AccessLog::new())),
     };
 
     (state, guard)


### PR DESCRIPTION
## Summary
- Record a timestamp on every proxied TCP connection, per service (`mac` + `local_port`)
- Keep last N records per service in a ring buffer (N from `storage.max_access_records`, default **2000**; `0` disables collection)
- Persist to `access_history.json`, flushed every 60s off-thread and once on graceful shutdown (Ctrl-C/SIGTERM)
- New endpoint `GET /api/machines/:mac/access-history`
- Leptos detail page renders a Chart.js multi-dataset bar chart, day-bucketed

## Design
- In-memory `AccessLog` (`HashMap<service_key, VecDeque<i64 epoch-millis>>`) in `AppState`
- Recorded on the accept path in `forward.rs`; in-memory only on the hot path (no disk IO per connection)
- Flush snapshots under a short read lock then writes via `spawn_blocking` (no lock across blocking IO)
- No client IP stored (privacy by design)
- Design doc: `docs/plans/2026-06-13-access-history-design.md`; plan: `docs/superpowers/plans/2026-06-13-access-history.md`

## Test Plan
- [x] `cargo build` clean, `cargo clippy --all-targets` clean
- [x] `cargo test` — all pass (ring-buffer cap, configurable cap, cap-0 disable, API endpoint integration)
- [x] Live e2e: real connections through proxy → `GET .../access-history` returned recorded timestamps; 60s flush confirmed in logs
- [ ] Reviewer: open detail page, confirm chart renders per service

## Follow-ups (non-blocking)
- Chart.js CDN lacks SRI hash / pins floating `@4`
- 60s flush interval hardcoded (could be config)
- No automated test for the accept-path recording (covered by live e2e only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added access history tracking for service connections, persisted across restarts.
  * New API endpoint to fetch a machine’s access history.
  * Machine details now show an “Access history” card with daily/hourly charts; the TUI now displays a last-14-days access-history view.

* **Chores**
  * Added Chart.js to power the new charts in the web UI.
  * Updated repository ignore rules to exclude generated access-history and docs plan artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->