### PR TITLE
fix: stop Windows services during installer upgrade

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -11,6 +11,7 @@ $ProgressPreference = "SilentlyContinue"
 
 $BinName = "wakezilla"
 $ExeName = "wakezilla.exe"
+$WakezillaServiceNames = @("wakezilla-proxy", "wakezilla-client")
 
 function Write-Info {
     param([string]$Message)
@@ -243,6 +244,53 @@ function Expand-WakezillaArchive {
     $binary.FullName
 }
 
+function Restart-WakezillaServicesAfterInstall {
+    param([string[]]$ServiceNames)
+
+    foreach ($serviceName in $ServiceNames) {
+        try {
+            Write-Info "starting Windows service $serviceName..."
+            Start-Service -Name $serviceName -ErrorAction Stop
+        }
+        catch {
+            Write-Warn "installed $BinName, but failed to restart Windows service '$serviceName': $($_.Exception.Message)"
+        }
+    }
+}
+
+function Stop-WakezillaServicesForInstall {
+    param([string[]]$ServiceNames = $WakezillaServiceNames)
+
+    $restartServices = @()
+    foreach ($serviceName in $ServiceNames) {
+        $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+        if (-not $service) {
+            continue
+        }
+
+        $wasRunning = $service.Status -eq "Running"
+        if ($service.Status -ne "Stopped") {
+            try {
+                Write-Info "stopping Windows service $serviceName before updating $ExeName..."
+                Stop-Service -Name $serviceName -Force -ErrorAction Stop
+                $service.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Stopped, [TimeSpan]::FromSeconds(30))
+            }
+            catch {
+                if ($restartServices.Count -gt 0) {
+                    Restart-WakezillaServicesAfterInstall -ServiceNames $restartServices
+                }
+                Stop-Install "service_stop" "failed to stop Windows service '$serviceName' before updating $ExeName. Re-run the installer from an elevated PowerShell, or stop Wakezilla services manually and retry. Details: $($_.Exception.Message)"
+            }
+        }
+
+        if ($wasRunning) {
+            $restartServices += $serviceName
+        }
+    }
+
+    $restartServices
+}
+
 function Install-WakezillaBinary {
     param(
         [string]$Source,
@@ -257,8 +305,17 @@ function Install-WakezillaBinary {
         Remove-Item -Force $temporary
     }
 
-    Copy-Item -Force $Source $temporary
-    Move-Item -Force $temporary $destination
+    try {
+        Copy-Item -Force $Source $temporary
+        Move-Item -Force $temporary $destination
+    }
+    catch {
+        if (Test-Path $temporary) {
+            Remove-Item -Force $temporary -ErrorAction SilentlyContinue
+        }
+        Stop-Install "install" "failed to replace $destination. Stop any running Wakezilla service or process and retry from an elevated PowerShell. Details: $($_.Exception.Message)"
+    }
+
     $destination
 }
 
@@ -309,6 +366,7 @@ function Invoke-WakezillaInstall {
         Remove-Item -Recurse -Force $tmpDir
     }
     New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+    $servicesToRestart = @()
 
     try {
         $assetName = [System.IO.Path]::GetFileName(([System.Uri]$assetUrl).LocalPath)
@@ -323,6 +381,7 @@ function Invoke-WakezillaInstall {
         Assert-Checksum -File $archive -ChecksumsText $checksumsText -AssetName $assetName
 
         $binary = Expand-WakezillaArchive -Archive $archive -OutDir (Join-Path $tmpDir "extract")
+        $servicesToRestart = @(Stop-WakezillaServicesForInstall)
         $installed = Install-WakezillaBinary -Source $binary -DestinationDir $binDir
 
         if (-not $NoPath) {
@@ -353,6 +412,9 @@ function Invoke-WakezillaInstall {
         }
     }
     finally {
+        if ($servicesToRestart.Count -gt 0) {
+            Restart-WakezillaServicesAfterInstall -ServiceNames $servicesToRestart
+        }
         if (Test-Path $tmpDir) {
             Remove-Item -Recurse -Force $tmpDir
         }

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -117,9 +117,87 @@ function Test-ArchiveAndInstall {
     }
 }
 
+function New-MockService {
+    param(
+        [string]$Name,
+        [string]$Status
+    )
+
+    $service = [pscustomobject]@{
+        Name   = $Name
+        Status = $Status
+    }
+    $service | Add-Member -MemberType ScriptMethod -Name WaitForStatus -Value {
+        param(
+            [object]$Status,
+            [TimeSpan]$Timeout
+        )
+        $script:WaitedServices += "$($this.Name):$Status"
+        $this.Status = $Status
+    }
+    $service
+}
+
+function Get-Service {
+    param(
+        [string]$Name,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]]$Remaining
+    )
+
+    if ($script:MockServices -and $script:MockServices.ContainsKey($Name)) {
+        return $script:MockServices[$Name]
+    }
+}
+
+function Stop-Service {
+    param(
+        [string]$Name,
+        [switch]$Force,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]]$Remaining
+    )
+
+    $script:StoppedServices += $Name
+    $script:MockServices[$Name].Status = "Stopped"
+}
+
+function Start-Service {
+    param(
+        [string]$Name,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]]$Remaining
+    )
+
+    $script:StartedServices += $Name
+}
+
+function Test-ServiceStopAndRestartHelpers {
+    $script:MockServices = @{
+        "wakezilla-proxy"  = New-MockService -Name "wakezilla-proxy" -Status "Running"
+        "wakezilla-client" = New-MockService -Name "wakezilla-client" -Status "Stopped"
+    }
+    $script:StoppedServices = @()
+    $script:StartedServices = @()
+    $script:WaitedServices = @()
+
+    $restartServices = @(Stop-WakezillaServicesForInstall -ServiceNames @("wakezilla-proxy", "wakezilla-client"))
+
+    Assert-Equal 1 $restartServices.Count "restart service count"
+    Assert-Equal "wakezilla-proxy" $restartServices[0] "restart service name"
+    Assert-Equal 1 $script:StoppedServices.Count "stopped service count"
+    Assert-Equal "wakezilla-proxy" $script:StoppedServices[0] "stopped service name"
+    Assert-Equal "wakezilla-proxy:Stopped" $script:WaitedServices[0] "waited service"
+
+    Restart-WakezillaServicesAfterInstall -ServiceNames $restartServices
+    Assert-Equal 1 $script:StartedServices.Count "started service count"
+    Assert-Equal "wakezilla-proxy" $script:StartedServices[0] "started service name"
+}
+
 Test-TargetDetection
 Test-ReleaseHelpers
 Test-ChecksumHelpers
 Test-ArchiveAndInstall
+Test-ServiceStopAndRestartHelpers
 
 Write-Host "install.ps1 tests passed"


### PR DESCRIPTION
## Summary
- stop running Wakezilla Windows services before replacing wakezilla.exe
- restart services that were running after the installer finishes
- add PowerShell installer coverage for stop/restart helper behavior

## Validation
- cargo fmt --all -- --check
- cargo test --test setup_tests --locked
- sh -n install.sh scripts/test-install-sh.sh
- git diff --check

Note: local machine does not have pwsh installed, so scripts/test-install-ps1.ps1 will be covered by the Windows CI job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installation reliability by safely stopping related services before replacing the app and restarting them afterward.
  * Added clearer installer error handling so failed file replacement cleans up temporary files and reports a more specific failure.
  * Expanded installer coverage with automated checks for service stop/restart behavior during install flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->