### PR TITLE
fix: stop standalone Windows processes during install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -291,6 +291,83 @@ function Stop-WakezillaServicesForInstall {
     $restartServices
 }
 
+function Test-SamePath {
+    param(
+        [string]$Left,
+        [string]$Right
+    )
+
+    if (-not $Left -or -not $Right) {
+        return $false
+    }
+
+    try {
+        $Left = [System.IO.Path]::GetFullPath($Left)
+    }
+    catch {
+    }
+
+    try {
+        $Right = [System.IO.Path]::GetFullPath($Right)
+    }
+    catch {
+    }
+
+    $Left.TrimEnd("\") -ieq $Right.TrimEnd("\")
+}
+
+function Get-WakezillaProcessesForInstall {
+    param([string]$ExecutablePath)
+
+    if (-not (Test-Path $ExecutablePath)) {
+        return @()
+    }
+
+    try {
+        @(Get-CimInstance Win32_Process -Filter "name = '$ExeName'" -ErrorAction Stop |
+            Where-Object { Test-SamePath $_.ExecutablePath $ExecutablePath })
+    }
+    catch {
+        Write-Warn "failed to inspect running $ExeName processes before install: $($_.Exception.Message)"
+        @()
+    }
+}
+
+function Stop-WakezillaProcessesForInstall {
+    param([string]$ExecutablePath)
+
+    $processes = @(Get-WakezillaProcessesForInstall -ExecutablePath $ExecutablePath)
+    if ($processes.Count -eq 0) {
+        return
+    }
+
+    foreach ($process in $processes) {
+        try {
+            Write-Info "stopping running $ExeName process $($process.ProcessId) before updating..."
+            Stop-Process -Id $process.ProcessId -Force -ErrorAction Stop
+        }
+        catch {
+            Stop-Install "process_stop" "failed to stop running $ExeName process $($process.ProcessId) before updating $ExecutablePath. Stop Wakezilla manually and retry. Details: $($_.Exception.Message)"
+        }
+    }
+
+    $deadline = [DateTime]::UtcNow.AddSeconds(30)
+    foreach ($process in $processes) {
+        while ([DateTime]::UtcNow -lt $deadline) {
+            $running = Get-CimInstance Win32_Process -Filter "ProcessId = $($process.ProcessId)" -ErrorAction SilentlyContinue
+            if (-not $running) {
+                break
+            }
+            Start-Sleep -Milliseconds 250
+        }
+
+        $stillRunning = Get-CimInstance Win32_Process -Filter "ProcessId = $($process.ProcessId)" -ErrorAction SilentlyContinue
+        if ($stillRunning) {
+            Stop-Install "process_stop" "running $ExeName process $($process.ProcessId) did not exit before updating $ExecutablePath"
+        }
+    }
+}
+
 function Install-WakezillaBinary {
     param(
         [string]$Source,
@@ -304,6 +381,8 @@ function Install-WakezillaBinary {
     if (Test-Path $temporary) {
         Remove-Item -Force $temporary
     }
+
+    Stop-WakezillaProcessesForInstall -ExecutablePath $destination
 
     try {
         Copy-Item -Force $Source $temporary

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -172,6 +172,59 @@ function Start-Service {
     $script:StartedServices += $Name
 }
 
+function New-MockProcess {
+    param(
+        [int]$ProcessId,
+        [string]$ExecutablePath
+    )
+
+    [pscustomobject]@{
+        ProcessId      = $ProcessId
+        ExecutablePath = $ExecutablePath
+        Running        = $true
+    }
+}
+
+function Get-CimInstance {
+    param(
+        [string]$ClassName,
+        [string]$Filter,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]]$Remaining
+    )
+
+    if ($ClassName -ne "Win32_Process" -or -not $script:MockProcesses) {
+        return @()
+    }
+
+    if ($Filter -match "^name = 'wakezilla\.exe'$") {
+        return @($script:MockProcesses.Values | Where-Object { $_.Running })
+    }
+
+    if ($Filter -match "^ProcessId = (\d+)$") {
+        $id = [int]$Matches[1]
+        if ($script:MockProcesses.ContainsKey($id) -and $script:MockProcesses[$id].Running) {
+            return $script:MockProcesses[$id]
+        }
+    }
+
+    @()
+}
+
+function Stop-Process {
+    param(
+        [int]$Id,
+        [switch]$Force,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [object[]]$Remaining
+    )
+
+    $script:StoppedProcesses += $Id
+    if ($script:MockProcesses -and $script:MockProcesses.ContainsKey($Id)) {
+        $script:MockProcesses[$Id].Running = $false
+    }
+}
+
 function Test-ServiceStopAndRestartHelpers {
     $script:MockServices = @{
         "wakezilla-proxy"  = New-MockService -Name "wakezilla-proxy" -Status "Running"
@@ -194,10 +247,39 @@ function Test-ServiceStopAndRestartHelpers {
     Assert-Equal "wakezilla-proxy" $script:StartedServices[0] "started service name"
 }
 
+function Test-ProcessStopHelper {
+    $tempDir = New-Item -ItemType Directory -Force -Path (Join-Path ([System.IO.Path]::GetTempPath()) "wakezilla-ps1-process-$PID")
+    try {
+        $targetExe = Join-Path $tempDir "wakezilla.exe"
+        $otherExe = Join-Path $tempDir "other\wakezilla.exe"
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $otherExe) | Out-Null
+        Set-Content -NoNewline -Path $targetExe -Value "target"
+        Set-Content -NoNewline -Path $otherExe -Value "other"
+
+        $script:MockProcesses = @{
+            1001 = New-MockProcess -ProcessId 1001 -ExecutablePath $targetExe
+            1002 = New-MockProcess -ProcessId 1002 -ExecutablePath $otherExe
+        }
+        $script:StoppedProcesses = @()
+
+        Stop-WakezillaProcessesForInstall -ExecutablePath $targetExe
+
+        Assert-Equal 1 $script:StoppedProcesses.Count "stopped process count"
+        Assert-Equal 1001 $script:StoppedProcesses[0] "stopped target process"
+        Assert-Equal $false $script:MockProcesses[1001].Running "target process stopped"
+        Assert-Equal $true $script:MockProcesses[1002].Running "other process left running"
+    }
+    finally {
+        $script:MockProcesses = $null
+        Remove-Item -Recurse -Force $tempDir
+    }
+}
+
 Test-TargetDetection
 Test-ReleaseHelpers
 Test-ChecksumHelpers
 Test-ArchiveAndInstall
 Test-ServiceStopAndRestartHelpers
+Test-ProcessStopHelper
 
 Write-Host "install.ps1 tests passed"


### PR DESCRIPTION
## Summary
- stop running wakezilla.exe processes that point to the install destination before replacing the binary
- keep the existing Windows service stop/restart behavior
- add PowerShell installer coverage for process detection and termination

## CI evidence
- Reproduced failure in Windows GitHub Actions with a standalone wakezilla.exe process holding the installed binary: run 28488570471
- Verified the branch installer fixes that repro: run 28488686982
- Verified the public install command after publishing the site installer: run 28488856383

## Validation
- cargo fmt --all -- --check
- cargo test --test setup_tests --locked
- git diff --check
- GitHub Actions Windows installer repro passed with `irm https://wakezilla.dev/install.ps1 | iex`