### PR TITLE
chore: print installer stack traces

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -48,15 +48,48 @@ function Get-WakezillaTarget {
     }
 
     if (-not $Architecture) {
-        $Architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+        $Architecture = Get-WindowsArchitecture
     }
 
-    switch -Regex ($Architecture.ToLowerInvariant()) {
+    switch -Regex ($Architecture.ToString().ToLowerInvariant()) {
         "^(x64|x86_64|amd64)$" { return "x86_64-pc-windows-msvc" }
         default {
             Stop-Install "platform" "unsupported Windows architecture: $Architecture"
         }
     }
+}
+
+function Get-WindowsArchitecture {
+    param(
+        [string]$RuntimeArchitecture = $null,
+        [string]$Wow64Architecture = $env:PROCESSOR_ARCHITEW6432,
+        [string]$ProcessorArchitecture = $env:PROCESSOR_ARCHITECTURE
+    )
+
+    if ($RuntimeArchitecture) {
+        return $RuntimeArchitecture
+    }
+
+    if (-not $PSBoundParameters.ContainsKey("RuntimeArchitecture")) {
+        try {
+            $detected = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+            if ($detected) {
+                return $detected.ToString()
+            }
+        }
+        catch {
+        }
+    }
+
+    if ($Wow64Architecture) {
+        return $Wow64Architecture
+    }
+
+    if ($ProcessorArchitecture) {
+        return $ProcessorArchitecture
+    }
+
+    Stop-Install "platform" "unable to detect Windows architecture"
 }
 
 function Resolve-InstallDir {

--- a/install.ps1
+++ b/install.ps1
@@ -504,4 +504,16 @@ if ($env:WAKEZILLA_INSTALL_PS1_TEST_MODE) {
     return
 }
 
-Invoke-WakezillaInstall
+try {
+    Invoke-WakezillaInstall
+}
+catch {
+    [Console]::Error.WriteLine("Wakezilla installer failed: $($_.Exception.Message)")
+    if ($_.ScriptStackTrace) {
+        [Console]::Error.WriteLine($_.ScriptStackTrace)
+    }
+    if ($_.InvocationInfo -and $_.InvocationInfo.PositionMessage) {
+        [Console]::Error.WriteLine($_.InvocationInfo.PositionMessage)
+    }
+    throw
+}

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -54,6 +54,8 @@ function New-TestRelease {
 function Test-TargetDetection {
     Assert-Equal "custom-target" (Get-WakezillaTarget -TargetOverride "custom-target") "target override"
     Assert-Equal "x86_64-pc-windows-msvc" (Get-WakezillaTarget -Architecture "X64") "windows x64 target"
+    Assert-Equal "AMD64" (Get-WindowsArchitecture -RuntimeArchitecture "" -Wow64Architecture "AMD64" -ProcessorArchitecture "x86") "wow64 architecture fallback"
+    Assert-Equal "AMD64" (Get-WindowsArchitecture -RuntimeArchitecture "" -Wow64Architecture "" -ProcessorArchitecture "AMD64") "processor architecture fallback"
 }
 
 function Test-ReleaseHelpers {


### PR DESCRIPTION
## Summary
- print the installer exception message, PowerShell script stack trace, and position before rethrowing
- keep installer behavior unchanged, but make `irm ... | iex` failures actionable when they only show the top-level `iex` line

## Validation
- cargo fmt --all -- --check
- cargo test --test setup_tests --locked
- git diff --check

The same installer copy is already deployed to wakezilla.dev/install.ps1 for diagnostics.