### PR TITLE
Fix Windows tray context menu startup

### DIFF
--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 use tray_icon::{
-    menu::{MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
+    menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
     Icon, TrayIcon, TrayIconBuilder,
 };
 use winit::{
@@ -336,7 +336,7 @@ impl ServiceControl {
     }
 }
 
-fn build_menu() -> Result<(Submenu, TrayMenu)> {
+fn build_menu() -> Result<(Menu, TrayMenu)> {
     let open_dashboard = MenuItem::with_id(OPEN_DASHBOARD_ID, "Open dashboard", true, None);
     let copy_dashboard_url =
         MenuItem::with_id(COPY_DASHBOARD_URL_ID, "Copy dashboard URL", true, None);
@@ -353,7 +353,7 @@ fn build_menu() -> Result<(Submenu, TrayMenu)> {
     let separator3 = PredefinedMenuItem::separator();
     let separator4 = PredefinedMenuItem::separator();
 
-    let root = Submenu::new("Wakezilla", true);
+    let root = Menu::new();
     root.append_items(&[
         &message,
         &separator1,


### PR DESCRIPTION
## Summary
- Use `Menu` as the tray context menu root instead of `Submenu`.
- Keep Proxy and Client entries as submenus under the root menu.

## Why
The Windows backend for the tray/menu stack treats root menus and submenus differently when subclassing native window callbacks. Passing a `Submenu` as the tray root can hit the wrong callback path during startup and produce a native Windows failure like `0xc000041d`.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --locked --features desktop-tray`
- `cargo clippy --workspace --all-targets --locked --features desktop-tray -- -D warnings`
- `cargo test --locked --features desktop-tray`

Note: attempted `cargo check --locked --target x86_64-pc-windows-msvc --features desktop-tray`, but local macOS cross-check is blocked by missing MSVC C headers while compiling `ring`, before reaching project code.