### PR TITLE
Fix tray-launched PowerShell commands on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5772,6 +5772,7 @@ dependencies = [
  "askama",
  "askama_axum",
  "axum",
+ "base64 0.22.1",
  "clap",
  "config 0.14.1",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,14 @@ resolver = "2"
 
 [features]
 default = []
-desktop-tray = ["dep:arboard", "dep:open", "dep:png", "dep:tray-icon", "dep:winit"]
+desktop-tray = [
+    "dep:arboard",
+    "dep:base64",
+    "dep:open",
+    "dep:png",
+    "dep:tray-icon",
+    "dep:winit",
+]
 
 [profile.wasm-release]
 inherits = "release"
@@ -79,6 +86,7 @@ sha2 = "0.10"
 flate2 = "1.0"
 tar = "0.4"
 tempfile = "3"
+base64 = { version = "0.22.1", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", all(target_os = "linux", not(target_env = "musl"))))'.dependencies]
 arboard = { version = "3.6.1", default-features = false, features = ["wayland-data-control"], optional = true }

--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -1,5 +1,7 @@
 use crate::{config, service, update};
 use anyhow::{anyhow, Context, Result};
+#[cfg(target_os = "windows")]
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use std::io::Cursor;
 use std::path::Path;
 use std::process::Command;
@@ -246,6 +248,7 @@ impl TrayApp {
         let result = open_wakezilla_command(
             true,
             &[
+                "--no-update-check",
                 "service",
                 "logs",
                 "--mode",
@@ -484,7 +487,13 @@ fn run_service_control(mode: service::Mode, control: ServiceControl) -> Result<S
 
     open_wakezilla_command(
         true,
-        &["service", control.verb(), "--mode", mode.service_arg()],
+        &[
+            "--no-update-check",
+            "service",
+            control.verb(),
+            "--mode",
+            mode.service_arg(),
+        ],
         true,
     )?;
     Ok(format!(
@@ -742,13 +751,18 @@ fn open_macos_terminal(parts: &[String], keep_open: bool) -> Result<()> {
 #[cfg(target_os = "windows")]
 fn open_command(elevated: bool, exe: &Path, args: &[&str], keep_open: bool) -> Result<()> {
     let ps_command = powershell_invocation(exe, args);
+    let encoded_command = powershell_encoded_command(&ps_command);
+    let mut powershell_args = vec!["-NoProfile", "-ExecutionPolicy", "Bypass"];
+    if keep_open {
+        powershell_args.push("-NoExit");
+    }
+    powershell_args.push("-EncodedCommand");
+    powershell_args.push(&encoded_command);
+    let argument_list = powershell_array_literal(&powershell_args);
 
     if elevated {
-        let no_exit = if keep_open { "-NoExit " } else { "" };
-        let argument_list = format!("{no_exit}-Command {}", powershell_quote(&ps_command));
         let script = format!(
-            "Start-Process powershell -Verb RunAs -ArgumentList {}",
-            powershell_quote(&argument_list)
+            "Start-Process -FilePath powershell -Verb RunAs -ArgumentList @({argument_list})"
         );
         let mut command = Command::new("powershell");
         command.args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command"]);
@@ -757,14 +771,11 @@ fn open_command(elevated: bool, exe: &Path, args: &[&str], keep_open: bool) -> R
             .spawn()
             .context("failed to open elevated PowerShell")?;
     } else {
-        let mut command = Command::new("cmd");
-        command.args(["/C", "start", "", "powershell"]);
-        if keep_open {
-            command.arg("-NoExit");
-        }
+        let script = format!("Start-Process -FilePath powershell -ArgumentList @({argument_list})");
+        let mut command = Command::new("powershell");
+        command.args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command"]);
         command
-            .arg("-Command")
-            .arg(&ps_command)
+            .arg(&script)
             .spawn()
             .context("failed to open PowerShell")?;
     }
@@ -805,6 +816,24 @@ fn powershell_invocation(exe: &Path, args: &[&str]) -> String {
         .collect::<Vec<_>>()
         .join(" ");
     format!("& {invocation}")
+}
+
+#[cfg(target_os = "windows")]
+fn powershell_encoded_command(command: &str) -> String {
+    let bytes: Vec<u8> = command
+        .encode_utf16()
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect();
+    BASE64_STANDARD.encode(bytes)
+}
+
+#[cfg(target_os = "windows")]
+fn powershell_array_literal(values: &[&str]) -> String {
+    values
+        .iter()
+        .map(|value| powershell_quote(value))
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary
- Launch Windows tray commands through PowerShell `-EncodedCommand` instead of nested quoted `-Command` strings.
- Pass `--no-update-check` for tray-launched service control/log commands.
- Keep elevated terminal windows open after service commands complete.

## Why
Manual `wakezilla.exe service logs` works, but commands opened from the tray go through `Start-Process` and nested quoting. Using `-EncodedCommand` avoids argument parsing differences between the tray launcher and an interactive PowerShell prompt.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --locked --features desktop-tray`
- `cargo clippy --workspace --all-targets --locked --features desktop-tray -- -D warnings`
- `cargo test --locked --features desktop-tray`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows tray actions by using a more reliable command-launch flow.
  * Added a `no-update-check` flag when opening logs or running elevated service controls.

* **Bug Fixes**
  * Fixed Windows tray command execution to better handle elevated actions like start, stop, and restart.
  * Reduced issues caused by quoted command arguments when launching PowerShell from the tray.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->