### PR TITLE
Fix Windows tray launcher console window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Check Windows backend
         run: cargo check -p wakezilla --all-targets --locked --features desktop-tray
 
+      - name: Check Windows tray
+        run: cargo check -p wakezilla --bin wakezilla-tray --features desktop-tray --locked
+
       - name: Run Windows backend tests
         run: cargo test -p wakezilla -p wakezilla-common --locked
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,6 @@ jobs:
       - name: Check Windows backend
         run: cargo check -p wakezilla --all-targets --locked --features desktop-tray
 
-      - name: Check Windows tray
-        run: cargo check -p wakezilla --bin wakezilla-tray --features desktop-tray --locked
-
       - name: Run Windows backend tests
         run: cargo test -p wakezilla -p wakezilla-common --locked
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,11 @@ jobs:
           fi
           cargo build --release --target "${TARGET}" "${FEATURES[@]}"
 
+      - name: Build Windows tray binary
+        if: ${{ contains(matrix.target, 'windows') }}
+        shell: bash
+        run: cargo build --release --target ${{ matrix.target }} --bin wakezilla-tray --features desktop-tray
+
       - name: Create release archive
         shell: bash
         run: |
@@ -112,14 +117,23 @@ jobs:
           TARGET="${{ matrix.target }}"
           ARCHIVE="wakezilla-${VERSION}-${TARGET}.tar.gz"
           BIN="wakezilla"
+          EXTRA_BINS=()
           if [[ "${TARGET}" == *windows* ]]; then
             BIN="wakezilla.exe"
+            EXTRA_BINS=("wakezilla-tray.exe")
           fi
           mkdir -p release
           cp "target/${TARGET}/release/${BIN}" "release/${BIN}"
           chmod +x "release/${BIN}"
-          tar -C release -czf "release/${ARCHIVE}" "${BIN}"
+          for extra_bin in "${EXTRA_BINS[@]}"; do
+            cp "target/${TARGET}/release/${extra_bin}" "release/${extra_bin}"
+            chmod +x "release/${extra_bin}"
+          done
+          tar -C release -czf "release/${ARCHIVE}" "${BIN}" "${EXTRA_BINS[@]}"
           rm -f "release/${BIN}"
+          for extra_bin in "${EXTRA_BINS[@]}"; do
+            rm -f "release/${extra_bin}"
+          done
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ include = [
     "LICENSE",
 ]
 
+[[bin]]
+name = "wakezilla-tray"
+path = "src/bin/wakezilla-tray.rs"
+required-features = ["desktop-tray"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/src/bin/wakezilla-tray.rs
+++ b/src/bin/wakezilla-tray.rs
@@ -1,0 +1,5 @@
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+
+fn main() -> anyhow::Result<()> {
+    wakezilla::tray::run()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod scanner;
 pub mod service;
 pub mod setup;
 pub mod system;
+pub mod tray;
 pub mod update;
 pub mod web;
 pub mod wol;

--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -595,7 +595,12 @@ fn wakezilla_cli_exe() -> Result<PathBuf> {
         return Ok(exe);
     }
 
-    Ok(sibling_exe(&exe, "wakezilla").unwrap_or(exe))
+    sibling_exe(&exe, "wakezilla").with_context(|| {
+        format!(
+            "failed to find wakezilla CLI executable next to {}",
+            exe.display()
+        )
+    })
 }
 
 fn wakezilla_tray_command() -> Result<(PathBuf, Vec<&'static str>)> {

--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context, Result};
 #[cfg(target_os = "windows")]
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use std::io::Cursor;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 use tray_icon::{
@@ -585,13 +585,51 @@ fn rgba_from_png_frame(bytes: &[u8], color_type: png::ColorType) -> Result<Vec<u
 }
 
 fn open_wakezilla_command(elevated: bool, args: &[&str], keep_open: bool) -> Result<()> {
-    let exe = std::env::current_exe().context("failed to resolve wakezilla executable")?;
+    let exe = wakezilla_cli_exe()?;
     open_command(elevated, &exe, args, keep_open)
+}
+
+fn wakezilla_cli_exe() -> Result<PathBuf> {
+    let exe = std::env::current_exe().context("failed to resolve wakezilla executable")?;
+    if !is_wakezilla_tray_exe(&exe) {
+        return Ok(exe);
+    }
+
+    Ok(sibling_exe(&exe, "wakezilla").unwrap_or(exe))
+}
+
+fn wakezilla_tray_command() -> Result<(PathBuf, Vec<&'static str>)> {
+    let exe = std::env::current_exe().context("failed to resolve wakezilla executable")?;
+    if is_wakezilla_tray_exe(&exe) {
+        return Ok((exe, Vec::new()));
+    }
+
+    if let Some(tray_exe) = sibling_exe(&exe, "wakezilla-tray") {
+        return Ok((tray_exe, Vec::new()));
+    }
+
+    Ok((exe, vec!["tray"]))
+}
+
+fn is_wakezilla_tray_exe(exe: &Path) -> bool {
+    exe.file_stem()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("wakezilla-tray"))
+}
+
+fn sibling_exe(exe: &Path, name: &str) -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    let file_name = format!("{name}.exe");
+    #[cfg(not(target_os = "windows"))]
+    let file_name = name;
+
+    let candidate = exe.parent()?.join(file_name);
+    candidate.is_file().then_some(candidate)
 }
 
 #[cfg(target_os = "linux")]
 fn install_tray_autostart() -> Result<std::path::PathBuf> {
-    let exe = std::env::current_exe().context("failed to resolve wakezilla executable")?;
+    let (exe, args) = wakezilla_tray_command()?;
     let config_home = std::env::var_os("XDG_CONFIG_HOME")
         .map(std::path::PathBuf::from)
         .or_else(|| {
@@ -606,10 +644,10 @@ fn install_tray_autostart() -> Result<std::path::PathBuf> {
         "[Desktop Entry]\n\
          Type=Application\n\
          Name=Wakezilla Tray\n\
-         Exec={} tray\n\
+         Exec={}\n\
          Terminal=false\n\
          X-GNOME-Autostart-enabled=true\n",
-        desktop_entry_quote(&exe.to_string_lossy()),
+        desktop_entry_command(&exe, &args),
     );
     std::fs::write(&path, content)
         .with_context(|| format!("failed to write {}", path.display()))?;
@@ -618,7 +656,7 @@ fn install_tray_autostart() -> Result<std::path::PathBuf> {
 
 #[cfg(target_os = "macos")]
 fn install_tray_autostart() -> Result<std::path::PathBuf> {
-    let exe = std::env::current_exe().context("failed to resolve wakezilla executable")?;
+    let (exe, args) = wakezilla_tray_command()?;
     let home = std::env::var_os("HOME")
         .map(std::path::PathBuf::from)
         .context("HOME is required to install tray autostart")?;
@@ -636,13 +674,14 @@ fn install_tray_autostart() -> Result<std::path::PathBuf> {
          \t<key>ProgramArguments</key>\n\
          \t<array>\n\
          \t\t<string>{}</string>\n\
-         \t\t<string>tray</string>\n\
+         {}\
          \t</array>\n\
          \t<key>RunAtLoad</key>\n\
          \t<true/>\n\
          </dict>\n\
          </plist>\n",
         xml_escape(&exe.to_string_lossy()),
+        plist_args(&args),
     );
     std::fs::write(&path, content)
         .with_context(|| format!("failed to write {}", path.display()))?;
@@ -651,8 +690,8 @@ fn install_tray_autostart() -> Result<std::path::PathBuf> {
 
 #[cfg(target_os = "windows")]
 fn install_tray_autostart() -> Result<std::path::PathBuf> {
-    let exe = std::env::current_exe().context("failed to resolve wakezilla executable")?;
-    let command = format!("\"{}\" tray", exe.display());
+    let (exe, args) = wakezilla_tray_command()?;
+    let command = windows_command(&exe, &args);
     let status = Command::new("reg")
         .args([
             "add",
@@ -674,6 +713,14 @@ fn install_tray_autostart() -> Result<std::path::PathBuf> {
 }
 
 #[cfg(target_os = "linux")]
+fn desktop_entry_command(exe: &Path, args: &[&str]) -> String {
+    std::iter::once(desktop_entry_quote(&exe.to_string_lossy()))
+        .chain(args.iter().map(|arg| desktop_entry_quote(arg)))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(target_os = "linux")]
 fn desktop_entry_quote(value: &str) -> String {
     format!(
         "\"{}\"",
@@ -685,6 +732,13 @@ fn desktop_entry_quote(value: &str) -> String {
 }
 
 #[cfg(target_os = "macos")]
+fn plist_args(args: &[&str]) -> String {
+    args.iter()
+        .map(|arg| format!("\t\t<string>{}</string>\n", xml_escape(arg)))
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
 fn xml_escape(value: &str) -> String {
     value
         .replace('&', "&amp;")
@@ -692,6 +746,14 @@ fn xml_escape(value: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+#[cfg(target_os = "windows")]
+fn windows_command(exe: &Path, args: &[&str]) -> String {
+    std::iter::once(format!("\"{}\"", exe.display()))
+        .chain(args.iter().map(|arg| format!("\"{arg}\"")))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]


### PR DESCRIPTION
## Summary

Adds a dedicated `wakezilla-tray` binary that runs the existing desktop tray implementation without attaching a Windows console window.

## Details

- Keeps `wakezilla.exe` as the console CLI/service executable.
- Adds `wakezilla-tray.exe` as a GUI-subsystem wrapper for the tray app.
- Updates tray startup helpers so service/setup/log commands still use the CLI executable when the tray wrapper is running.
- Updates Windows CI/release packaging so the tray wrapper is checked and included in Windows archives.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p wakezilla --all-targets --locked --features desktop-tray`
- `cargo check -p wakezilla --bin wakezilla-tray --features desktop-tray --locked`
- `cargo clippy -p wakezilla --all-targets --locked --features desktop-tray -- -D warnings`
- `cargo test -p wakezilla -p wakezilla-common --locked`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated desktop tray app for Windows and included it in release builds.
  * The app now packages the correct tray executable for each platform.

* **Bug Fixes**
  * Improved how tray launch commands are generated on Windows, macOS, and Linux.
  * Fixed startup behavior so the tray app can find and run the right companion binary automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->