### PR TITLE
Fix release archive packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,22 +117,22 @@ jobs:
           TARGET="${{ matrix.target }}"
           ARCHIVE="wakezilla-${VERSION}-${TARGET}.tar.gz"
           BIN="wakezilla"
-          EXTRA_BINS=()
           if [[ "${TARGET}" == *windows* ]]; then
             BIN="wakezilla.exe"
-            EXTRA_BINS=("wakezilla-tray.exe")
           fi
+          ARCHIVE_ITEMS=("${BIN}")
           mkdir -p release
           cp "target/${TARGET}/release/${BIN}" "release/${BIN}"
           chmod +x "release/${BIN}"
-          for extra_bin in "${EXTRA_BINS[@]}"; do
+          if [[ "${TARGET}" == *windows* ]]; then
+            extra_bin="wakezilla-tray.exe"
             cp "target/${TARGET}/release/${extra_bin}" "release/${extra_bin}"
             chmod +x "release/${extra_bin}"
-          done
-          tar -C release -czf "release/${ARCHIVE}" "${BIN}" "${EXTRA_BINS[@]}"
-          rm -f "release/${BIN}"
-          for extra_bin in "${EXTRA_BINS[@]}"; do
-            rm -f "release/${extra_bin}"
+            ARCHIVE_ITEMS+=("${extra_bin}")
+          fi
+          tar -C release -czf "release/${ARCHIVE}" "${ARCHIVE_ITEMS[@]}"
+          for archive_item in "${ARCHIVE_ITEMS[@]}"; do
+            rm -f "release/${archive_item}"
           done
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- avoid expanding an empty extra-binaries array while creating release archives
- keep packaging wakezilla-tray.exe only for Windows releases

## Root cause
The release workflow runs archive creation with set -u. On macOS Bash 3.2, expanding an empty "${EXTRA_BINS[@]}" in the tar command fails with "unbound variable" for non-Windows targets.

## Validation
- reproduced Bash 3.2 empty-array expansion failure locally
- simulated archive creation for x86_64-apple-darwin and x86_64-pc-windows-msvc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release archive packaging for desktop builds, including better handling of Windows files and cleanup during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->