### PR TITLE
Fix release tool cache across architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,19 +70,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            . frontend
-
-      - name: Cache Cargo bin directory
-        uses: actions/cache@v4
-        id: cache-cargo-bin
-        with:
-          path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-bin-v1
-          restore-keys: |
-            ${{ runner.os }}-cargo-bin-
+            .
+            frontend
 
       - name: Install Trunk
-        if: steps.cache-cargo-bin.outputs.cache-hit != 'true'
         shell: bash
         run: |
           if ! command -v trunk &> /dev/null; then


### PR DESCRIPTION
## What changed

- Remove the shared cross-architecture Cargo bin cache.
- Correct the Rust workspace cache entries.
- Install Trunk only when it is unavailable.

## Why

The release matrix restored an incompatible cached Trunk binary on the x86_64 musl job, causing an Exec format error and cancelling the release.

## Validation

- Parsed `.github/workflows/release.yml` as YAML.
- Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Rust dependency cache configuration for more reliable cache restoration across project workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->