### PR TITLE
Reuse frontend assets for musl tray release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,12 @@ jobs:
         run: |
           set -euo pipefail
           TARGET="${{ matrix.target }}"
+          mkdir -p target/musl-tray
+          cp -a target/frontend-dist target/musl-tray/frontend-dist
           docker run --rm \
             -e CARGO_TERM_COLOR=always \
             -e TARGET="${TARGET}" \
+            -e WAKEZILLA_USE_PREBUILT_FRONTEND=1 \
             -v "$PWD:/workspace" \
             -w /workspace \
             rust:1-alpine \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ include = [
     "frontend/public/**",
     "frontend-dist/**",
     "build.rs",
+    "build_support.rs",
     "common/Cargo.toml",
     "common/src/**",
     "Cargo.toml",

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+mod build_support;
+
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -12,6 +14,8 @@ fn main() {
     println!("cargo:rerun-if-changed=frontend/Cargo.lock");
     println!("cargo:rerun-if-changed=frontend/public");
     println!("cargo:rerun-if-changed=frontend-dist");
+    println!("cargo:rerun-if-changed=build_support.rs");
+    println!("cargo:rerun-if-env-changed=WAKEZILLA_USE_PREBUILT_FRONTEND");
 
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("missing CARGO_MANIFEST_DIR");
     let frontend_dir = Path::new(&manifest_dir).join("frontend");
@@ -28,7 +32,12 @@ fn main() {
 
     let is_release = env::var("PROFILE").as_deref() == Ok("release");
     let frontend_index = frontend_dist_dir.join("index.html");
-    let must_build = is_release || !frontend_index.is_file();
+    let use_prebuilt_frontend = env::var("WAKEZILLA_USE_PREBUILT_FRONTEND").as_deref() == Ok("1");
+    let must_build = build_support::frontend_build_is_required(
+        is_release,
+        frontend_index.is_file(),
+        use_prebuilt_frontend,
+    );
 
     // Keep debug builds fast when frontend assets already exist.
     if !must_build {

--- a/build_support.rs
+++ b/build_support.rs
@@ -1,0 +1,7 @@
+pub fn frontend_build_is_required(
+    is_release: bool,
+    frontend_index_exists: bool,
+    use_prebuilt_frontend: bool,
+) -> bool {
+    !frontend_index_exists || (is_release && !use_prebuilt_frontend)
+}

--- a/tests/build_script_tests.rs
+++ b/tests/build_script_tests.rs
@@ -1,0 +1,9 @@
+#[path = "../build_support.rs"]
+mod build_support;
+
+#[test]
+fn release_build_reuses_a_prebuilt_frontend_when_available() {
+    assert!(!build_support::frontend_build_is_required(true, true, true));
+    assert!(build_support::frontend_build_is_required(true, false, true));
+    assert!(build_support::frontend_build_is_required(true, true, false));
+}


### PR DESCRIPTION
## What changed

- Reuse the frontend assets already built by the release workflow when building the Linux musl tray helper.
- Keep normal builds unchanged and rebuild if the prebuilt frontend is absent.

## Why

The musl helper container rebuilt and bootstrapped the frontend toolchain for each architecture. Both musl jobs remained in that step for nearly six hours and were cancelled.

## Validation

- `cargo test -p wakezilla --test build_script_tests --locked`
- `WAKEZILLA_USE_PREBUILT_FRONTEND=1 cargo build -p wakezilla --release --locked --features desktop-tray --bin wakezilla-tray`
- `cargo fmt --all -- --check`
- Parsed `.github/workflows/release.yml` as YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Distribution**
  * Improved Linux musl package builds by reusing available prebuilt frontend assets.
  * Ensured required build support files are included in published packages.

* **Bug Fixes**
  * Prevented unnecessary frontend rebuilding during release builds when prebuilt assets are available.

* **Tests**
  * Added coverage for frontend build decisions across release and asset-availability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->