### PR TITLE
Link the musl tray helper dynamically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,10 @@ jobs:
               set -eu
               export PATH=/usr/local/cargo/bin:$PATH
               apk add --no-cache build-base pkgconf gtk+3.0-dev libayatana-appindicator-dev
-              CARGO_TARGET_DIR=target/musl-tray cargo build --release --target "$TARGET" --bin wakezilla-tray --features desktop-tray
+              # The helper needs GTK/AppIndicator shared objects, unlike the
+              # server-only musl binary which remains statically linked.
+              RUSTFLAGS="-C target-feature=-crt-static" \
+                CARGO_TARGET_DIR=target/musl-tray cargo build --release --target "$TARGET" --bin wakezilla-tray --features desktop-tray
               cp "target/musl-tray/$TARGET/release/wakezilla-tray" "target/$TARGET/release/wakezilla-tray"
             '
 


### PR DESCRIPTION
## What changed

- Build only the Linux musl tray helper with dynamic CRT linkage.

## Why

The helper depends on GTK and AppIndicator shared libraries. Static musl linkage made the linker look for unavailable `.a` versions of GTK, GLib, Pango, and related libraries.

The server-only `wakezilla` binary remains statically linked.

## Validation

- Parsed `.github/workflows/release.yml` as YAML.
- `cargo fmt --all -- --check`
- `cargo test -p wakezilla --test build_script_tests --locked`
- `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux musl tray helper release builds for better runtime compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->