### PR TITLE
Fix Windows PowerShell 5.1 installer compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,37 @@ jobs:
         shell: pwsh
         run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test-install-ps1.ps1
 
+      - name: Run Windows PowerShell 5.1 installer tests
+        shell: powershell
+        run: |
+          $logDir = Join-Path $env:RUNNER_TEMP "wakezilla-installer-logs"
+          $logPath = Join-Path $logDir "windows-powershell-5.1.log"
+          New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+          "PowerShell version: $($PSVersionTable.PSVersion)" | Tee-Object -FilePath $logPath
+          "PowerShell edition: $($PSVersionTable.PSEdition)" | Tee-Object -FilePath $logPath -Append
+          try {
+            & .\scripts\test-install-ps1.ps1 *>&1 |
+              Tee-Object -FilePath $logPath -Append
+          }
+          catch {
+            $_ | Format-List * -Force | Out-String |
+              Tee-Object -FilePath $logPath -Append
+            if ($_.Exception) {
+              $_.Exception | Format-List * -Force | Out-String |
+                Tee-Object -FilePath $logPath -Append
+            }
+            throw
+          }
+
+      - name: Upload PowerShell installer logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-powershell-installer-logs
+          path: ${{ runner.temp }}\wakezilla-installer-logs
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Check Windows backend
         run: cargo check -p wakezilla --all-targets --locked --features desktop-tray
 

--- a/install.ps1
+++ b/install.ps1
@@ -48,15 +48,48 @@ function Get-WakezillaTarget {
     }
 
     if (-not $Architecture) {
-        $Architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+        $Architecture = Get-WindowsArchitecture
     }
 
-    switch -Regex ($Architecture.ToLowerInvariant()) {
+    switch -Regex ($Architecture.ToString().ToLowerInvariant()) {
         "^(x64|x86_64|amd64)$" { return "x86_64-pc-windows-msvc" }
         default {
             Stop-Install "platform" "unsupported Windows architecture: $Architecture"
         }
     }
+}
+
+function Get-WindowsArchitecture {
+    param(
+        [string]$RuntimeArchitecture = $null,
+        [string]$Wow64Architecture = $env:PROCESSOR_ARCHITEW6432,
+        [string]$ProcessorArchitecture = $env:PROCESSOR_ARCHITECTURE
+    )
+
+    if ($RuntimeArchitecture) {
+        return $RuntimeArchitecture
+    }
+
+    if (-not $PSBoundParameters.ContainsKey("RuntimeArchitecture")) {
+        try {
+            $detected = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+            if ($detected) {
+                return $detected.ToString()
+            }
+        }
+        catch {
+        }
+    }
+
+    if ($Wow64Architecture) {
+        return $Wow64Architecture
+    }
+
+    if ($ProcessorArchitecture) {
+        return $ProcessorArchitecture
+    }
+
+    Stop-Install "platform" "unable to detect Windows architecture"
 }
 
 function Resolve-InstallDir {

--- a/install.ps1
+++ b/install.ps1
@@ -306,7 +306,7 @@ function Stop-WakezillaServicesForInstall {
             try {
                 Write-Info "stopping Windows service $serviceName before updating $ExeName..."
                 Stop-Service -Name $serviceName -Force -ErrorAction Stop
-                $service.WaitForStatus([System.ServiceProcess.ServiceControllerStatus]::Stopped, [TimeSpan]::FromSeconds(30))
+                $service.WaitForStatus("Stopped", [TimeSpan]::FromSeconds(30))
             }
             catch {
                 if ($restartServices.Count -gt 0) {

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -54,6 +54,7 @@ function New-TestRelease {
 function Test-TargetDetection {
     Assert-Equal "custom-target" (Get-WakezillaTarget -TargetOverride "custom-target") "target override"
     Assert-Equal "x86_64-pc-windows-msvc" (Get-WakezillaTarget -Architecture "X64") "windows x64 target"
+    Assert-Equal "x86_64-pc-windows-msvc" (Get-WakezillaTarget) "automatic Windows target"
 }
 
 function Test-ReleaseHelpers {

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -55,6 +55,8 @@ function Test-TargetDetection {
     Assert-Equal "custom-target" (Get-WakezillaTarget -TargetOverride "custom-target") "target override"
     Assert-Equal "x86_64-pc-windows-msvc" (Get-WakezillaTarget -Architecture "X64") "windows x64 target"
     Assert-Equal "x86_64-pc-windows-msvc" (Get-WakezillaTarget) "automatic Windows target"
+    Assert-Equal "AMD64" (Get-WindowsArchitecture -RuntimeArchitecture "" -Wow64Architecture "AMD64" -ProcessorArchitecture "x86") "wow64 architecture fallback"
+    Assert-Equal "AMD64" (Get-WindowsArchitecture -RuntimeArchitecture "" -Wow64Architecture "" -ProcessorArchitecture "AMD64") "processor architecture fallback"
 }
 
 function Test-ReleaseHelpers {


### PR DESCRIPTION
## Summary

Fixes the installer for Windows PowerShell 5.1 and keeps that runtime covered in CI.

- detects Windows architecture through `RuntimeInformation` when available, with `PROCESSOR_ARCHITEW6432` and `PROCESSOR_ARCHITECTURE` fallbacks
- avoids a static `ServiceControllerStatus` enum dependency when waiting for services to stop
- exercises automatic and legacy architecture detection
- runs the installer suite under both PowerShell 7 and Windows PowerShell 5.1
- uploads the Windows PowerShell 5.1 diagnostic log on every Windows CI run

## Root cause

The installer called `RuntimeInformation.OSArchitecture.ToString()` directly. On Windows PowerShell 5.1 environments where that property is unavailable, the property resolves to null and `.ToString()` raises `InvokeMethodOnNull`.

The existing CI used only PowerShell 7, so it did not cover the documented Windows PowerShell command. Once the 5.1 suite was added, it also exposed a static `ServiceControllerStatus` type dependency that was not reliably resolved in that runtime.

## Validation

- [green CI run 29154246250](https://github.com/guibeira/wakezilla/actions/runs/29154246250)
- Windows job passed under PowerShell 7 and Windows PowerShell 5.1
- [Windows PowerShell 5.1 log artifact](https://github.com/guibeira/wakezilla/actions/runs/29154246250/artifacts/8249028140)
- all PR checks passed: fmt, clippy, coverage, frontend, install script, macOS preflight, and Windows
- `cargo fmt --all -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows architecture detection during installation, including fallback handling for different environment configurations.
  * Improved service shutdown compatibility when updating on Windows.

* **Tests**
  * Expanded installer tests to verify automatic Windows target detection and architecture fallbacks.
  * Added dedicated Windows PowerShell 5.1 installer test execution with failure logs available as CI artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->