### PR TITLE
Fix Windows installer upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,49 @@ jobs:
       - name: Run Windows backend tests
         run: cargo test -p wakezilla -p wakezilla-common --locked
 
+  windows-powershell-2022:
+    name: Windows PowerShell 5.1 (2022)
+    runs-on: windows-2022
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run Windows PowerShell 5.1 installer tests
+        shell: powershell
+        run: |
+          $logDir = Join-Path $env:RUNNER_TEMP "wakezilla-installer-logs"
+          $logPath = Join-Path $logDir "windows-server-2022-powershell-5.1.log"
+          New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+          "PowerShell version: $($PSVersionTable.PSVersion)" | Tee-Object -FilePath $logPath
+          "PowerShell edition: $($PSVersionTable.PSEdition)" | Tee-Object -FilePath $logPath -Append
+          try {
+            & .\scripts\test-install-ps1.ps1 *>&1 |
+              Tee-Object -FilePath $logPath -Append
+          }
+          catch {
+            $_ | Format-List * -Force | Out-String |
+              Tee-Object -FilePath $logPath -Append
+            if ($_.Exception) {
+              $_.Exception | Format-List * -Force | Out-String |
+                Tee-Object -FilePath $logPath -Append
+            }
+            throw
+          }
+
+      - name: Upload Windows PowerShell 5.1 logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-server-2022-powershell-installer-logs
+          path: ${{ runner.temp }}\wakezilla-installer-logs
+          if-no-files-found: warn
+          retention-days: 7
+
   frontend:
     name: frontend
     runs-on: ubuntu-latest

--- a/install.ps1
+++ b/install.ps1
@@ -471,6 +471,15 @@ function Get-RegularReleaseFile {
     $item.FullName
 }
 
+function Publish-WakezillaFile {
+    param(
+        [string]$Source,
+        [string]$Destination
+    )
+
+    Copy-Item -LiteralPath $Source -Destination $Destination -Force
+}
+
 function New-WakezillaShortcut {
     param(
         [string]$Path,
@@ -571,11 +580,11 @@ function Install-WakezillaDesktopIntegration {
         }
         Stop-WakezillaProcessesForInstall -ExecutablePath $cli
         Stop-WakezillaProcessesForInstall -ExecutablePath $tray
-        Move-Item -LiteralPath (Join-Path $temporary "wakezilla.exe") -Destination $cli -Force
+        Publish-WakezillaFile -Source (Join-Path $temporary "wakezilla.exe") -Destination $cli
         $published += $cli
-        Move-Item -LiteralPath (Join-Path $temporary "wakezilla-tray.exe") -Destination $tray -Force
+        Publish-WakezillaFile -Source (Join-Path $temporary "wakezilla-tray.exe") -Destination $tray
         $published += $tray
-        Move-Item -LiteralPath (Join-Path $temporary "wakezilla.ico") -Destination $icon -Force
+        Publish-WakezillaFile -Source (Join-Path $temporary "wakezilla.ico") -Destination $icon
         $published += $icon
         $uninstaller = Get-WakezillaUninstallScript -InstallRoot $installRoot
         New-WakezillaShortcut -Path $programShortcut -TargetPath $tray -WorkingDirectory $BinDir -IconPath $icon

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -132,6 +132,23 @@ function Test-ArchiveAndInstall {
     }
 }
 
+function Test-ExistingFileReplacement {
+    $tempDir = New-Item -ItemType Directory -Force -Path (Join-Path ([System.IO.Path]::GetTempPath()) "wakezilla-ps1-replacement-$PID")
+    try {
+        $source = Join-Path $tempDir "wakezilla.exe.new"
+        $destination = Join-Path $tempDir "wakezilla.exe"
+        Set-Content -NoNewline -Path $source -Value "new executable"
+        Set-Content -NoNewline -Path $destination -Value "old executable"
+
+        Move-Item -LiteralPath $source -Destination $destination -Force
+
+        Assert-Equal "new executable" (Get-Content -Raw -Path $destination) "replacement binary contents"
+    }
+    finally {
+        Remove-Item -Recurse -Force $tempDir
+    }
+}
+
 function New-MockService {
     param(
         [string]$Name,
@@ -295,6 +312,7 @@ Test-ReleaseHelpers
 Test-GuiInstallationContracts
 Test-ChecksumHelpers
 Test-ArchiveAndInstall
+Test-ExistingFileReplacement
 Test-ServiceStopAndRestartHelpers
 Test-ProcessStopHelper
 

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -140,7 +140,7 @@ function Test-ExistingFileReplacement {
         Set-Content -NoNewline -Path $source -Value "new executable"
         Set-Content -NoNewline -Path $destination -Value "old executable"
 
-        Move-Item -LiteralPath $source -Destination $destination -Force
+        Publish-WakezillaFile -Source $source -Destination $destination
 
         Assert-Equal "new executable" (Get-Content -Raw -Path $destination) "replacement binary contents"
     }


### PR DESCRIPTION
## Summary

Fixes the Windows installer when upgrading an existing installation.

- publishes the CLI, tray executable, and icon with `Copy-Item -Force`, which replaces existing files
- adds an installer regression test for publishing a replacement over an existing `wakezilla.exe`
- adds a lightweight Windows Server 2022 PowerShell 5.1 installer job with retained logs

## Root cause

The reported failure occurs at `Move-Item` while publishing the new `wakezilla.exe` over the existing installation:

```
Move-Item : Cannot create a file when that file already exists.
```

The installer previously relied on `Move-Item -Force` to replace the three published files. That operation is not a reliable replacement primitive across Windows environments. The installer now copies the staged file with `Copy-Item -Force`, after it has stopped matching Wakezilla processes.

The direct existing-file scenario did not reproduce the literal `Move-Item` error on GitHub-hosted Windows 2022/2025 runners, so the runner behavior differs from the affected machine. The replacement contract is now tested in both environments.

## Validation

- [green CI run 29154843319](https://github.com/guibeira/wakezilla/actions/runs/29154843319)
- Windows job passed, including PowerShell 7, Windows PowerShell 5.1, Rust build, and backend tests
- [Windows PowerShell 5.1 log](https://github.com/guibeira/wakezilla/actions/runs/29154843319/artifacts/8249181941)
- [Windows Server 2022 PowerShell 5.1 log](https://github.com/guibeira/wakezilla/actions/runs/29154843319/artifacts/8249177555)
- all PR checks passed
- `cargo fmt --all -- --check`