### PR TITLE
Stop Windows services before installer upgrades

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -644,6 +644,7 @@ function Invoke-WakezillaInstall {
         Remove-Item -Recurse -Force $tmpDir
     }
     New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+    $servicesToRestart = @()
     try {
         $assetName = [System.IO.Path]::GetFileName(([System.Uri]$assetUrl).LocalPath)
         $archive = Join-Path $tmpDir $assetName
@@ -658,6 +659,7 @@ function Invoke-WakezillaInstall {
 
         $extractDir = Join-Path $tmpDir "extract"
         $binary = Expand-WakezillaArchive -Archive $archive -OutDir $extractDir
+        $servicesToRestart = @(Stop-WakezillaServicesForInstall)
         $integration = Install-WakezillaDesktopIntegration -ExtractDir $extractDir -BinDir $binDir -InstallVersion $releaseVersion
         $installed = $integration.Cli
 
@@ -689,6 +691,9 @@ function Invoke-WakezillaInstall {
         }
     }
     finally {
+        if ($servicesToRestart.Count -gt 0) {
+            Restart-WakezillaServicesAfterInstall -ServiceNames $servicesToRestart
+        }
         if (Test-Path $tmpDir) {
             Remove-Item -Recurse -Force $tmpDir
         }

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -86,6 +86,12 @@ function Test-GuiInstallationContracts {
     Assert-Contains $content 'Arguments = ""' "shortcut no-arguments contract"
 }
 
+function Test-InstallerServiceUpgradeContract {
+    $content = Get-Content -Raw -Path $Script
+    Assert-Contains $content '$servicesToRestart = @(Stop-WakezillaServicesForInstall)' "stop services before upgrade"
+    Assert-Contains $content 'Restart-WakezillaServicesAfterInstall -ServiceNames $servicesToRestart' "restart services after upgrade"
+}
+
 function Test-ChecksumHelpers {
     $tempDir = New-Item -ItemType Directory -Force -Path (Join-Path ([System.IO.Path]::GetTempPath()) "wakezilla-ps1-checksum-$PID")
     try {
@@ -310,6 +316,7 @@ function Test-ProcessStopHelper {
 Test-TargetDetection
 Test-ReleaseHelpers
 Test-GuiInstallationContracts
+Test-InstallerServiceUpgradeContract
 Test-ChecksumHelpers
 Test-ArchiveAndInstall
 Test-ExistingFileReplacement


### PR DESCRIPTION
## Summary

Restores the Windows service lifecycle around installer upgrades.

- stops `wakezilla-proxy` and `wakezilla-client` before publishing the new CLI, tray, and icon
- restarts only services that had been running after the upgrade
- adds a regression test for that lifecycle

## Root cause

The `Copy-Item` sharing violation means the existing executable is still open. The tray integration had removed `Stop-WakezillaServicesForInstall` and `Restart-WakezillaServicesAfterInstall` from `Invoke-WakezillaInstall`, allowing a previously configured Windows service to keep Wakezilla open while the installer replaces it.

## Validation

- [CI run 29155248684](https://github.com/guibeira/wakezilla/actions/runs/29155248684) passed
- Windows job: PowerShell 7, Windows PowerShell 5.1, Rust build, and tests passed
- [PowerShell installer log](https://github.com/guibeira/wakezilla/actions/runs/29155248684/artifacts/8249283341)
- [Windows Server 2022 PowerShell installer log](https://github.com/guibeira/wakezilla/actions/runs/29155248684/artifacts/8249279626)
- all PR checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows services stopped during installation are now automatically restarted afterward, including when installation encounters an error.
  * Prevents installed services from remaining stopped after upgrades.

* **Tests**
  * Added coverage to verify the installer’s service stop-and-restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->