### PR TITLE
Fix Windows service setup and user installer updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,35 @@ jobs:
           if ((Get-Subsystem $cli) -ne 3) { throw 'wakezilla.exe must be a console PE (subsystem 3)' }
           if ((Get-Subsystem $tray) -ne 2) { throw 'wakezilla-tray.exe must be a GUI PE (subsystem 2)' }
 
+      - name: Reconfigure an installed Windows service
+        shell: pwsh
+        run: |
+          $logDir = Join-Path $env:RUNNER_TEMP "wakezilla-service-setup-logs"
+          $logPath = Join-Path $logDir "windows-service-setup.log"
+          New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+          try {
+            & .\scripts\test-windows-service-setup.ps1 *>&1 |
+              Tee-Object -FilePath $logPath
+          }
+          catch {
+            $_ | Format-List * -Force | Out-String |
+              Tee-Object -FilePath $logPath -Append
+            if ($_.Exception) {
+              $_.Exception | Format-List * -Force | Out-String |
+                Tee-Object -FilePath $logPath -Append
+            }
+            throw
+          }
+
+      - name: Upload Windows service setup logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-service-setup-logs
+          path: ${{ runner.temp }}\wakezilla-service-setup-logs
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Run Windows backend tests
         run: cargo test -p wakezilla -p wakezilla-common --locked
 

--- a/install.ps1
+++ b/install.ps1
@@ -291,6 +291,34 @@ function Restart-WakezillaServicesAfterInstall {
     }
 }
 
+function Test-WakezillaServiceUsesProtectedBinary {
+    param([string]$ServiceName)
+
+    try {
+        $service = Get-CimInstance Win32_Service -Filter "Name = '$ServiceName'" -ErrorAction Stop
+        if (-not $service -or -not $service.PathName) {
+            return $false
+        }
+
+        $imagePath = [string]$service.PathName
+        if ($imagePath -notmatch '^\s*"([^"]+)"') {
+            return $false
+        }
+
+        $programFiles = if ($env:ProgramW6432) { $env:ProgramW6432 } else { $env:ProgramFiles }
+        if (-not $programFiles) {
+            return $false
+        }
+
+        $protectedBinary = Join-Path (Join-Path $programFiles "Wakezilla\Service") "$serviceName.exe"
+        Test-SamePath $Matches[1] $protectedBinary
+    }
+    catch {
+        Write-Warn "failed to inspect Windows service '$serviceName' before updating $ExeName: $($_.Exception.Message)"
+        $false
+    }
+}
+
 function Stop-WakezillaServicesForInstall {
     param([string[]]$ServiceNames = $WakezillaServiceNames)
 
@@ -298,6 +326,10 @@ function Stop-WakezillaServicesForInstall {
     foreach ($serviceName in $ServiceNames) {
         $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
         if (-not $service) {
+            continue
+        }
+
+        if (Test-WakezillaServiceUsesProtectedBinary -ServiceName $serviceName) {
             continue
         }
 

--- a/install.ps1
+++ b/install.ps1
@@ -314,7 +314,7 @@ function Test-WakezillaServiceUsesProtectedBinary {
         Test-SamePath $Matches[1] $protectedBinary
     }
     catch {
-        Write-Warn "failed to inspect Windows service '$serviceName' before updating $ExeName: $($_.Exception.Message)"
+        Write-Warn "failed to inspect Windows service '$serviceName' before updating ${ExeName}: $($_.Exception.Message)"
         $false
     }
 }

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -231,6 +231,17 @@ function Get-CimInstance {
         [object[]]$Remaining
     )
 
+    if ($ClassName -eq "Win32_Service" -and $Filter -match "^Name = '(.+)'$") {
+        $name = $Matches[1]
+        if ($script:MockServiceImages -and $script:MockServiceImages.ContainsKey($name)) {
+            return [pscustomobject]@{
+                Name = $name
+                PathName = $script:MockServiceImages[$name]
+            }
+        }
+        return @()
+    }
+
     if ($ClassName -ne "Win32_Process" -or -not $script:MockProcesses) {
         return @()
     }

--- a/scripts/test-install-ps1.ps1
+++ b/scripts/test-install-ps1.ps1
@@ -285,6 +285,23 @@ function Test-ServiceStopAndRestartHelpers {
     Assert-Equal "wakezilla-proxy" $script:StartedServices[0] "started service name"
 }
 
+function Test-ProtectedServicesDoNotRequireInstallerElevation {
+    $script:MockServices = @{
+        "wakezilla-proxy" = New-MockService -Name "wakezilla-proxy" -Status "Running"
+    }
+    $script:MockServiceImages = @{
+        "wakezilla-proxy" = '"C:\Program Files\Wakezilla\Service\wakezilla-proxy.exe" --no-update-check windows-service proxy'
+    }
+    $script:StoppedServices = @()
+    $script:StartedServices = @()
+    $script:WaitedServices = @()
+
+    $restartServices = @(Stop-WakezillaServicesForInstall -ServiceNames @("wakezilla-proxy"))
+
+    Assert-Equal 0 $restartServices.Count "protected service restart count"
+    Assert-Equal 0 $script:StoppedServices.Count "protected service stop count"
+}
+
 function Test-ProcessStopHelper {
     $tempDir = New-Item -ItemType Directory -Force -Path (Join-Path ([System.IO.Path]::GetTempPath()) "wakezilla-ps1-process-$PID")
     try {
@@ -321,6 +338,7 @@ Test-ChecksumHelpers
 Test-ArchiveAndInstall
 Test-ExistingFileReplacement
 Test-ServiceStopAndRestartHelpers
+Test-ProtectedServicesDoNotRequireInstallerElevation
 Test-ProcessStopHelper
 
 Write-Host "install.ps1 tests passed"

--- a/scripts/test-windows-service-setup.ps1
+++ b/scripts/test-windows-service-setup.ps1
@@ -31,6 +31,13 @@ try {
     Invoke-Wakezilla @("--no-update-check", "setup", "--mode", "client", "--port", "$secondPort", "--yes")
     Invoke-Wakezilla @("service", "status", "--mode", "client")
 }
+catch {
+    if (Test-Path $serviceRoot) {
+        $serviceAcl = Get-Acl -LiteralPath $serviceRoot
+        Write-Host "Wakezilla service directory SDDL: $($serviceAcl.Sddl)"
+    }
+    throw
+}
 finally {
     & $wakezilla "uninstall"
     if ($LASTEXITCODE -ne 0) {

--- a/scripts/test-windows-service-setup.ps1
+++ b/scripts/test-windows-service-setup.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$wakezilla = Join-Path $PSScriptRoot "..\target\debug\wakezilla.exe"
+$wakezilla = (Resolve-Path $wakezilla).Path
+$configRoot = Join-Path $env:ProgramData "wakezilla"
+$serviceRoot = Join-Path $env:ProgramFiles "Wakezilla"
+$firstPort = 39101
+$secondPort = 39102
+
+function Invoke-Wakezilla {
+    param([string[]]$Arguments)
+
+    & $wakezilla @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "wakezilla $($Arguments -join ' ') exited with code $LASTEXITCODE"
+    }
+}
+
+if (Test-Path $configRoot) {
+    throw "refusing to run service setup integration test because $configRoot already exists"
+}
+if (Test-Path $serviceRoot) {
+    throw "refusing to run service setup integration test because $serviceRoot already exists"
+}
+
+try {
+    Invoke-Wakezilla @("--no-update-check", "setup", "--mode", "client", "--port", "$firstPort", "--yes")
+    Invoke-Wakezilla @("service", "status", "--mode", "client")
+
+    Invoke-Wakezilla @("--no-update-check", "setup", "--mode", "client", "--port", "$secondPort", "--yes")
+    Invoke-Wakezilla @("service", "status", "--mode", "client")
+}
+finally {
+    & $wakezilla "uninstall"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "wakezilla uninstall exited with code $LASTEXITCODE during integration-test cleanup"
+    }
+    Remove-Item -Recurse -Force $configRoot -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $serviceRoot -ErrorAction SilentlyContinue
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<()> {
         }
         Commands::Setup(args) => {
             if let Err(e) = setup::run(args) {
-                error!("Setup error: {}", e);
+                error!("Setup error: {e:#}");
                 std::process::exit(1);
             }
         }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1097,6 +1097,14 @@ fn windows_security_sddl(path: &Path) -> Result<String> {
 }
 
 #[cfg(target_os = "windows")]
+fn windows_security_matches_expected(path: &Path, directory: bool) -> Result<bool> {
+    let expected = windows_full_security_sddl(directory);
+    let actual = windows_security_sddl(path)?;
+    let auto_inherited = expected.replacen("D:P", "D:PAI", 1);
+    Ok(actual == expected || actual == auto_inherited)
+}
+
+#[cfg(target_os = "windows")]
 fn apply_windows_protected_security(path: &Path, directory: bool) -> Result<()> {
     use windows_sys::Win32::Foundation::{LocalFree, ERROR_SUCCESS};
     use windows_sys::Win32::Security::Authorization::{
@@ -1166,7 +1174,7 @@ fn apply_windows_protected_security(path: &Path, directory: bool) -> Result<()> 
             status
         );
     }
-    if windows_security_sddl(path)? != expected {
+    if !windows_security_matches_expected(path, directory)? {
         anyhow::bail!(
             "protected Windows ACL verification failed for {}",
             path.display()
@@ -1399,7 +1407,7 @@ fn begin_protected_binary_update(
                 destination.display()
             );
         }
-        if windows_security_sddl(&destination)? != windows_full_security_sddl(false) {
+        if !windows_security_matches_expected(&destination, false)? {
             anyhow::bail!(
                 "existing protected service binary {} has an unsafe ACL; remove it manually and rerun setup",
                 destination.display()
@@ -1456,7 +1464,7 @@ fn begin_protected_binary_update(
     };
     let validation = (|| -> Result<()> {
         windows_path_has_no_reparse_components(&update.destination)?;
-        if windows_security_sddl(&update.destination)? != windows_full_security_sddl(false) {
+        if !windows_security_matches_expected(&update.destination, false)? {
             anyhow::bail!(
                 "published protected service binary {} has an unsafe ACL",
                 update.destination.display()
@@ -1480,7 +1488,7 @@ fn validate_windows_protected_binary(mode: Mode) -> Result<PathBuf> {
     let path = protected_service_binary_path(mode)?;
     windows_path_has_no_reparse_components(&path)?;
     if !std::fs::symlink_metadata(&path)?.file_type().is_file()
-        || windows_security_sddl(&path)? != windows_full_security_sddl(false)
+        || !windows_security_matches_expected(&path, false)?
     {
         anyhow::bail!(
             "protected Windows service binary {} is missing or has unsafe metadata",
@@ -1811,7 +1819,7 @@ fn remove_protected_service_binary(mode: Mode) -> Result<()> {
         Ok(metadata) => {
             windows_path_has_no_reparse_components(&binary)?;
             if !metadata.file_type().is_file()
-                || windows_security_sddl(&binary)? != windows_full_security_sddl(false)
+                || !windows_security_matches_expected(&binary, false)?
             {
                 anyhow::bail!(
                     "refusing to remove unsafe or foreign protected Windows binary {}",

--- a/src/service.rs
+++ b/src/service.rs
@@ -126,7 +126,20 @@ pub fn windows_image_path_uses_protected_binary(
             .to_ascii_lowercase()
     }
 
-    normalized(image_path) == normalized(&windows_service_binary_path_in(program_files, mode))
+    let protected = windows_service_binary_path_in(program_files, mode);
+    if normalized(image_path) == normalized(&protected) {
+        return true;
+    }
+
+    let image_path = image_path.to_string_lossy();
+    let Some(command) = image_path.strip_prefix('"') else {
+        return false;
+    };
+    let Some((executable, arguments)) = command.split_once('"') else {
+        return false;
+    };
+    let expected_arguments = format!(" {}", windows_service_program_args(mode).join(" "));
+    normalized(Path::new(executable)) == normalized(&protected) && arguments == expected_arguments
 }
 
 /// Protected DACL for the Windows service directory: full control for only

--- a/tests/setup_tests.rs
+++ b/tests/setup_tests.rs
@@ -168,6 +168,27 @@ fn windows_image_path_validation_rejects_user_writable_legacy_binary() {
 }
 
 #[test]
+fn windows_image_path_validation_accepts_only_the_canonical_service_command() {
+    let program_files = Path::new("C:/Program Files");
+    let canonical = Path::new(
+        r#""C:\Program Files\Wakezilla\Service\wakezilla-client.exe" --no-update-check windows-service client"#,
+    );
+    assert!(service::windows_image_path_uses_protected_binary(
+        program_files,
+        Mode::Client,
+        canonical
+    ));
+
+    let unexpected_args =
+        Path::new(r#""C:\Program Files\Wakezilla\Service\wakezilla-client.exe" client-server"#);
+    assert!(!service::windows_image_path_uses_protected_binary(
+        program_files,
+        Mode::Client,
+        unexpected_args
+    ));
+}
+
+#[test]
 fn windows_protected_acl_contract_allows_only_system_and_administrators() {
     let directory = service::windows_service_directory_sddl();
     let file = service::windows_service_file_sddl();


### PR DESCRIPTION
## Summary

Fixes the Windows service setup failure and allows normal user-level installer updates once the service has been migrated to the protected location.

- accepts the Windows `D:PAI` ACL representation after applying the protected service ACL
- validates the complete canonical Windows service command line instead of treating its arguments as part of an unsafe executable path
- skips protected `Program Files\Wakezilla\Service` services during user-installer updates
- keeps stopping legacy services so they can be migrated safely from an elevated `wakezilla setup`
- adds a real Windows Service Manager integration test: install, start, reconfigure, and remove the client service
- adds a PowerShell regression test for protected-service installer updates

## Root causes

1. Windows adds the auto-inherited `AI` marker to the protected directory ACL, producing `D:PAI...` rather than the exact input string `D:P...`. The ACL itself remained protected and restricted to LocalSystem and Administrators, but a literal SDDL comparison rejected it.
2. The `windows-service` crate returns the full SCM `ImagePath`, including launch arguments. The service checker compared that complete command line to the executable path and classified a freshly created protected service as legacy.
3. The installer stopped every named Wakezilla service. A protected service runs from `Program Files`, not from the per-user install directory, so stopping it is unnecessary and requires elevation. Legacy services remain an elevated migration path by design.

## Validation

- [CI run 29156881776](https://github.com/guibeira/wakezilla/actions/runs/29156881776) passed on rerun
- Windows job passed: PowerShell installer tests, Windows PowerShell 5.1 installer tests, real SCM install/reconfigure/remove test, Rust build, and backend tests
- Windows Server 2022 / PowerShell 5.1 job passed
- lint, format, coverage, frontend, macOS, and installer checks passed
- [Windows service setup log](https://github.com/guibeira/wakezilla/actions/runs/29156881776/artifacts/8249748124)
- [PowerShell installer log](https://github.com/guibeira/wakezilla/actions/runs/29156881776/artifacts/8249740394)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows service protection checks to recognize only valid protected service commands.
  * Prevented unnecessary service restarts during installation when services already use protected binaries.
  * Improved Windows security descriptor validation, including auto-inherited permissions.
  * Enhanced setup error output for easier troubleshooting.

* **Tests**
  * Added Windows integration coverage for service setup, cleanup, command validation, and protected-service installation behavior.
  * Windows CI now captures and uploads service setup logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->