### PR TITLE
fix: render macOS tray icon with internal details

### DIFF
--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -822,7 +822,7 @@ fn load_tray_icon() -> Result<Icon> {
 #[cfg(target_os = "macos")]
 fn macos_template_rgba(rgba: &mut [u8], width: u32, height: u32) {
     const OUTLINE_LUMA_MAX: u16 = 100;
-    const OUTLINE_RADIUS: usize = 4;
+    const OUTLINE_RADIUS: usize = 3;
 
     let width = usize::try_from(width).expect("tray icon width must fit usize");
     let height = usize::try_from(height).expect("tray icon height must fit usize");
@@ -1643,15 +1643,16 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_template_mask_thickens_dark_outline_pixels() {
-        let mut rgba = [
-            220, 100, 60, 255, // mascot fill
-            80, 30, 20, 255, // dark outline
-            220, 100, 60, 255, // mascot fill
-        ];
+        let mut rgba = vec![220, 100, 60, 255].repeat(9);
+        rgba[4 * 4..4 * 5].copy_from_slice(&[80, 30, 20, 255]);
 
-        macos_template_rgba(&mut rgba, 3, 1);
+        macos_template_rgba(&mut rgba, 9, 1);
 
-        assert_eq!(rgba, [0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255]);
+        let alpha = rgba
+            .chunks_exact(4)
+            .map(|pixel| pixel[3])
+            .collect::<Vec<_>>();
+        assert_eq!(alpha, [0, 255, 255, 255, 255, 255, 255, 255, 0]);
     }
 
     #[test]

--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -429,7 +429,7 @@ impl TrayApp {
             .with_menu_on_left_click(true);
 
         #[cfg(target_os = "macos")]
-        let tray_icon_builder = tray_icon_builder.with_icon_as_template(true);
+        let tray_icon_builder = tray_icon_builder.with_icon_as_template(false);
 
         let tray_icon = tray_icon_builder
             .build()
@@ -814,58 +814,28 @@ fn load_tray_icon() -> Result<Icon> {
     let mut rgba = rgba_from_png_frame(bytes, frame.color_type)?;
 
     #[cfg(target_os = "macos")]
-    macos_template_rgba(&mut rgba, frame.width, frame.height);
+    macos_monochrome_rgba(&mut rgba);
 
     Icon::from_rgba(rgba, frame.width, frame.height).context("failed to create tray icon")
 }
 
 #[cfg(target_os = "macos")]
-fn macos_template_rgba(rgba: &mut [u8], width: u32, height: u32) {
-    const OUTLINE_LUMA_MAX: u16 = 100;
-    const OUTLINE_RADIUS: usize = 3;
+fn macos_monochrome_rgba(rgba: &mut [u8]) {
+    const WHITE_LUMA_MIN: u16 = 180;
+    const GRAY_LUMA_MIN: u16 = 100;
 
-    let width = usize::try_from(width).expect("tray icon width must fit usize");
-    let height = usize::try_from(height).expect("tray icon height must fit usize");
-    let pixel_count = width
-        .checked_mul(height)
-        .expect("tray icon pixel count must fit usize");
-    assert_eq!(rgba.len(), pixel_count * 4, "tray icon must be RGBA");
-
-    let alpha = rgba
-        .chunks_exact(4)
-        .map(|pixel| pixel[3])
-        .collect::<Vec<_>>();
-    let dark_outline = rgba
-        .chunks_exact(4)
-        .map(|pixel| {
-            let luma =
-                54 * u16::from(pixel[0]) + 183 * u16::from(pixel[1]) + 19 * u16::from(pixel[2]);
-            pixel[3] != 0 && luma / 256 <= OUTLINE_LUMA_MAX
-        })
-        .collect::<Vec<_>>();
-    let mut outline_alpha = vec![0; pixel_count];
-
-    for y in 0..height {
-        for x in 0..width {
-            if !dark_outline[y * width + x] {
-                continue;
-            }
-            let y_start = y.saturating_sub(OUTLINE_RADIUS);
-            let y_end = y.saturating_add(OUTLINE_RADIUS).min(height - 1);
-            let x_start = x.saturating_sub(OUTLINE_RADIUS);
-            let x_end = x.saturating_add(OUTLINE_RADIUS).min(width - 1);
-            for target_y in y_start..=y_end {
-                for target_x in x_start..=x_end {
-                    let target = target_y * width + target_x;
-                    outline_alpha[target] = outline_alpha[target].max(alpha[target]);
-                }
-            }
+    for pixel in rgba.chunks_exact_mut(4) {
+        if pixel[3] == 0 {
+            continue;
         }
-    }
-
-    for (pixel, alpha) in rgba.chunks_exact_mut(4).zip(outline_alpha) {
-        pixel[..3].fill(0);
-        pixel[3] = alpha;
+        let luma =
+            (54 * u16::from(pixel[0]) + 183 * u16::from(pixel[1]) + 19 * u16::from(pixel[2])) / 256;
+        let tone = match luma {
+            WHITE_LUMA_MIN.. => 255,
+            GRAY_LUMA_MIN.. => 128,
+            _ => 0,
+        };
+        pixel[..3].fill(tone);
     }
 }
 
@@ -1628,31 +1598,20 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn macos_template_mask_keeps_dark_outline_pixels() {
+    fn macos_monochrome_icon_preserves_three_tones_and_alpha() {
         let mut rgba = [
-            220, 100, 60, 0, // transparent background
-            80, 30, 20, 180, // dark outline
+            240, 240, 240, 255, // white
+            128, 128, 128, 180, // gray
+            60, 60, 60, 200, // black
             220, 100, 60, 0, // transparent background
         ];
 
-        macos_template_rgba(&mut rgba, 3, 1);
+        macos_monochrome_rgba(&mut rgba);
 
-        assert_eq!(rgba, [0, 0, 0, 0, 0, 0, 0, 180, 0, 0, 0, 0]);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn macos_template_mask_thickens_dark_outline_pixels() {
-        let mut rgba = vec![220, 100, 60, 255].repeat(9);
-        rgba[4 * 4..4 * 5].copy_from_slice(&[80, 30, 20, 255]);
-
-        macos_template_rgba(&mut rgba, 9, 1);
-
-        let alpha = rgba
-            .chunks_exact(4)
-            .map(|pixel| pixel[3])
-            .collect::<Vec<_>>();
-        assert_eq!(alpha, [0, 255, 255, 255, 255, 255, 255, 255, 0]);
+        assert_eq!(
+            rgba,
+            [255, 255, 255, 255, 128, 128, 128, 180, 0, 0, 0, 200, 220, 100, 60, 0,]
+        );
     }
 
     #[test]

--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -814,27 +814,59 @@ fn load_tray_icon() -> Result<Icon> {
     let mut rgba = rgba_from_png_frame(bytes, frame.color_type)?;
 
     #[cfg(target_os = "macos")]
-    macos_monochrome_rgba(&mut rgba);
+    macos_white_mascot_rgba(&mut rgba, frame.width, frame.height);
 
     Icon::from_rgba(rgba, frame.width, frame.height).context("failed to create tray icon")
 }
 
 #[cfg(target_os = "macos")]
-fn macos_monochrome_rgba(rgba: &mut [u8]) {
-    const WHITE_LUMA_MIN: u16 = 180;
-    const GRAY_LUMA_MIN: u16 = 100;
+fn macos_white_mascot_rgba(rgba: &mut [u8], width: u32, height: u32) {
+    const DARK_LINE_LUMA_MAX: u16 = 100;
+    const INNER_LINE_MARGIN: usize = 2;
 
-    for pixel in rgba.chunks_exact_mut(4) {
-        if pixel[3] == 0 {
-            continue;
+    let width = usize::try_from(width).expect("tray icon width must fit usize");
+    let height = usize::try_from(height).expect("tray icon height must fit usize");
+    let pixel_count = width
+        .checked_mul(height)
+        .expect("tray icon pixel count must fit usize");
+    assert_eq!(rgba.len(), pixel_count * 4, "tray icon must be RGBA");
+
+    let alpha = rgba
+        .chunks_exact(4)
+        .map(|pixel| pixel[3])
+        .collect::<Vec<_>>();
+    let dark = rgba
+        .chunks_exact(4)
+        .map(|pixel| {
+            let luma =
+                (54 * u16::from(pixel[0]) + 183 * u16::from(pixel[1]) + 19 * u16::from(pixel[2]))
+                    / 256;
+            luma <= DARK_LINE_LUMA_MAX
+        })
+        .collect::<Vec<_>>();
+
+    for y in 0..height {
+        for x in 0..width {
+            let index = y * width + x;
+            let pixel = &mut rgba[index * 4..index * 4 + 4];
+            if alpha[index] == 0 {
+                continue;
+            }
+
+            let has_opaque_margin = x >= INNER_LINE_MARGIN
+                && y >= INNER_LINE_MARGIN
+                && x + INNER_LINE_MARGIN < width
+                && y + INNER_LINE_MARGIN < height
+                && (y - INNER_LINE_MARGIN..=y + INNER_LINE_MARGIN).all(|neighbor_y| {
+                    (x - INNER_LINE_MARGIN..=x + INNER_LINE_MARGIN)
+                        .all(|neighbor_x| alpha[neighbor_y * width + neighbor_x] != 0)
+                });
+            pixel[..3].fill(if dark[index] && has_opaque_margin {
+                0
+            } else {
+                255
+            });
         }
-        let luma =
-            (54 * u16::from(pixel[0]) + 183 * u16::from(pixel[1]) + 19 * u16::from(pixel[2])) / 256;
-        let tone = match luma {
-            GRAY_LUMA_MIN..WHITE_LUMA_MIN => 128,
-            _ => 255,
-        };
-        pixel[..3].fill(tone);
     }
 }
 
@@ -1597,20 +1629,15 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn macos_monochrome_icon_replaces_black_with_white_and_preserves_alpha() {
-        let mut rgba = [
-            240, 240, 240, 255, // white
-            128, 128, 128, 180, // gray
-            60, 60, 60, 200, // replaced with white
-            220, 100, 60, 0, // transparent background
-        ];
+    fn macos_white_mascot_keeps_only_interior_dark_lines() {
+        let mut rgba = vec![140, 90, 60, 255].repeat(25);
+        rgba[12 * 4..13 * 4].copy_from_slice(&[60, 60, 60, 255]);
 
-        macos_monochrome_rgba(&mut rgba);
+        macos_white_mascot_rgba(&mut rgba, 5, 5);
 
-        assert_eq!(
-            rgba,
-            [255, 255, 255, 255, 128, 128, 128, 180, 255, 255, 255, 200, 220, 100, 60, 0,]
-        );
+        let mut expected = vec![255; 25 * 4];
+        expected[12 * 4..13 * 4].copy_from_slice(&[0, 0, 0, 255]);
+        assert_eq!(rgba, expected);
     }
 
     #[test]

--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -811,9 +811,62 @@ fn load_tray_icon() -> Result<Icon> {
         .next_frame(&mut buffer)
         .context("failed to read tray icon frame")?;
     let bytes = &buffer[..frame.buffer_size()];
-    let rgba = rgba_from_png_frame(bytes, frame.color_type)?;
+    let mut rgba = rgba_from_png_frame(bytes, frame.color_type)?;
+
+    #[cfg(target_os = "macos")]
+    macos_template_rgba(&mut rgba, frame.width, frame.height);
 
     Icon::from_rgba(rgba, frame.width, frame.height).context("failed to create tray icon")
+}
+
+#[cfg(target_os = "macos")]
+fn macos_template_rgba(rgba: &mut [u8], width: u32, height: u32) {
+    const OUTLINE_LUMA_MAX: u16 = 100;
+    const OUTLINE_RADIUS: usize = 4;
+
+    let width = usize::try_from(width).expect("tray icon width must fit usize");
+    let height = usize::try_from(height).expect("tray icon height must fit usize");
+    let pixel_count = width
+        .checked_mul(height)
+        .expect("tray icon pixel count must fit usize");
+    assert_eq!(rgba.len(), pixel_count * 4, "tray icon must be RGBA");
+
+    let alpha = rgba
+        .chunks_exact(4)
+        .map(|pixel| pixel[3])
+        .collect::<Vec<_>>();
+    let dark_outline = rgba
+        .chunks_exact(4)
+        .map(|pixel| {
+            let luma =
+                54 * u16::from(pixel[0]) + 183 * u16::from(pixel[1]) + 19 * u16::from(pixel[2]);
+            pixel[3] != 0 && luma / 256 <= OUTLINE_LUMA_MAX
+        })
+        .collect::<Vec<_>>();
+    let mut outline_alpha = vec![0; pixel_count];
+
+    for y in 0..height {
+        for x in 0..width {
+            if !dark_outline[y * width + x] {
+                continue;
+            }
+            let y_start = y.saturating_sub(OUTLINE_RADIUS);
+            let y_end = y.saturating_add(OUTLINE_RADIUS).min(height - 1);
+            let x_start = x.saturating_sub(OUTLINE_RADIUS);
+            let x_end = x.saturating_add(OUTLINE_RADIUS).min(width - 1);
+            for target_y in y_start..=y_end {
+                for target_x in x_start..=x_end {
+                    let target = target_y * width + target_x;
+                    outline_alpha[target] = outline_alpha[target].max(alpha[target]);
+                }
+            }
+        }
+    }
+
+    for (pixel, alpha) in rgba.chunks_exact_mut(4).zip(outline_alpha) {
+        pixel[..3].fill(0);
+        pixel[3] = alpha;
+    }
 }
 
 fn rgba_from_png_frame(bytes: &[u8], color_type: png::ColorType) -> Result<Vec<u8>> {
@@ -1572,6 +1625,34 @@ fn powershell_quote(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_template_mask_keeps_dark_outline_pixels() {
+        let mut rgba = [
+            220, 100, 60, 0, // transparent background
+            80, 30, 20, 180, // dark outline
+            220, 100, 60, 0, // transparent background
+        ];
+
+        macos_template_rgba(&mut rgba, 3, 1);
+
+        assert_eq!(rgba, [0, 0, 0, 0, 0, 0, 0, 180, 0, 0, 0, 0]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_template_mask_thickens_dark_outline_pixels() {
+        let mut rgba = [
+            220, 100, 60, 255, // mascot fill
+            80, 30, 20, 255, // dark outline
+            220, 100, 60, 255, // mascot fill
+        ];
+
+        macos_template_rgba(&mut rgba, 3, 1);
+
+        assert_eq!(rgba, [0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255]);
+    }
 
     #[test]
     fn tray_instance_rejects_a_second_guard() {

--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -811,10 +811,14 @@ fn load_tray_icon() -> Result<Icon> {
         .next_frame(&mut buffer)
         .context("failed to read tray icon frame")?;
     let bytes = &buffer[..frame.buffer_size()];
-    let mut rgba = rgba_from_png_frame(bytes, frame.color_type)?;
+    let rgba = rgba_from_png_frame(bytes, frame.color_type)?;
 
     #[cfg(target_os = "macos")]
-    macos_white_mascot_rgba(&mut rgba, frame.width, frame.height);
+    let rgba = {
+        let mut rgba = rgba;
+        macos_white_mascot_rgba(&mut rgba, frame.width, frame.height);
+        rgba
+    };
 
     Icon::from_rgba(rgba, frame.width, frame.height).context("failed to create tray icon")
 }
@@ -1630,7 +1634,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_white_mascot_keeps_only_interior_dark_lines() {
-        let mut rgba = vec![140, 90, 60, 255].repeat(25);
+        let mut rgba = [140, 90, 60, 255].repeat(25);
         rgba[12 * 4..13 * 4].copy_from_slice(&[60, 60, 60, 255]);
 
         macos_white_mascot_rgba(&mut rgba, 5, 5);

--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -831,9 +831,8 @@ fn macos_monochrome_rgba(rgba: &mut [u8]) {
         let luma =
             (54 * u16::from(pixel[0]) + 183 * u16::from(pixel[1]) + 19 * u16::from(pixel[2])) / 256;
         let tone = match luma {
-            WHITE_LUMA_MIN.. => 255,
-            GRAY_LUMA_MIN.. => 128,
-            _ => 0,
+            GRAY_LUMA_MIN..WHITE_LUMA_MIN => 128,
+            _ => 255,
         };
         pixel[..3].fill(tone);
     }
@@ -1598,11 +1597,11 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn macos_monochrome_icon_preserves_three_tones_and_alpha() {
+    fn macos_monochrome_icon_replaces_black_with_white_and_preserves_alpha() {
         let mut rgba = [
             240, 240, 240, 255, // white
             128, 128, 128, 180, // gray
-            60, 60, 60, 200, // black
+            60, 60, 60, 200, // replaced with white
             220, 100, 60, 0, // transparent background
         ];
 
@@ -1610,7 +1609,7 @@ mod tests {
 
         assert_eq!(
             rgba,
-            [255, 255, 255, 255, 128, 128, 128, 180, 0, 0, 0, 200, 220, 100, 60, 0,]
+            [255, 255, 255, 255, 128, 128, 128, 180, 255, 255, 255, 200, 220, 100, 60, 0,]
         );
     }
 

--- a/src/tray/desktop.rs
+++ b/src/tray/desktop.rs
@@ -422,11 +422,16 @@ impl TrayApp {
         let (root_menu, tray_menu) = build_menu()?;
         let icon = load_tray_icon()?;
 
-        let tray_icon = TrayIconBuilder::new()
+        let tray_icon_builder = TrayIconBuilder::new()
             .with_tooltip("Wakezilla")
             .with_icon(icon)
             .with_menu(Box::new(root_menu))
-            .with_menu_on_left_click(true)
+            .with_menu_on_left_click(true);
+
+        #[cfg(target_os = "macos")]
+        let tray_icon_builder = tray_icon_builder.with_icon_as_template(true);
+
+        let tray_icon = tray_icon_builder
             .build()
             .context("failed to build tray icon")?;
 

--- a/tests/desktop_assets.rs
+++ b/tests/desktop_assets.rs
@@ -412,16 +412,16 @@ fn macos_icon_contains_all_canonical_png_representations() {
 }
 
 #[test]
-fn macos_tray_icon_uses_three_tone_rendering() {
+fn macos_tray_icon_uses_white_and_gray_rendering() {
     const TRAY_SOURCE: &str = include_str!("../src/tray/desktop.rs");
 
     assert!(
         TRAY_SOURCE.contains(".with_icon_as_template(false)"),
-        "the macOS tray icon must preserve white, gray, and black tones"
+        "the macOS tray icon must preserve white and gray tones"
     );
     assert!(
         TRAY_SOURCE.contains("macos_monochrome_rgba(&mut rgba);"),
-        "the macOS tray icon must convert the full mascot to three tones"
+        "the macOS tray icon must convert the full mascot to monochrome tones"
     );
 }
 

--- a/tests/desktop_assets.rs
+++ b/tests/desktop_assets.rs
@@ -412,16 +412,16 @@ fn macos_icon_contains_all_canonical_png_representations() {
 }
 
 #[test]
-fn macos_tray_icon_is_configured_as_a_template() {
+fn macos_tray_icon_uses_three_tone_rendering() {
     const TRAY_SOURCE: &str = include_str!("../src/tray/desktop.rs");
 
     assert!(
-        TRAY_SOURCE.contains(".with_icon_as_template(true)"),
-        "the macOS tray icon must use template rendering so the system supplies monochrome colors"
+        TRAY_SOURCE.contains(".with_icon_as_template(false)"),
+        "the macOS tray icon must preserve white, gray, and black tones"
     );
     assert!(
-        TRAY_SOURCE.contains("macos_template_rgba(&mut rgba, frame.width, frame.height);"),
-        "the macOS tray icon must keep only the mascot's outline before template rendering"
+        TRAY_SOURCE.contains("macos_monochrome_rgba(&mut rgba);"),
+        "the macOS tray icon must convert the full mascot to three tones"
     );
 }
 

--- a/tests/desktop_assets.rs
+++ b/tests/desktop_assets.rs
@@ -419,6 +419,10 @@ fn macos_tray_icon_is_configured_as_a_template() {
         TRAY_SOURCE.contains(".with_icon_as_template(true)"),
         "the macOS tray icon must use template rendering so the system supplies monochrome colors"
     );
+    assert!(
+        TRAY_SOURCE.contains("macos_template_rgba(&mut rgba, frame.width, frame.height);"),
+        "the macOS tray icon must keep only the mascot's outline before template rendering"
+    );
 }
 
 fn icns_without_chunk(bytes: &[u8], removed_kind: &[u8; 4]) -> Vec<u8> {

--- a/tests/desktop_assets.rs
+++ b/tests/desktop_assets.rs
@@ -411,20 +411,6 @@ fn macos_icon_contains_all_canonical_png_representations() {
     validate_macos_icon(MACOS_ICNS).unwrap_or_else(|error| panic!("{error}"));
 }
 
-#[test]
-fn macos_tray_icon_uses_white_mascot_with_internal_lines() {
-    const TRAY_SOURCE: &str = include_str!("../src/tray/desktop.rs");
-
-    assert!(
-        TRAY_SOURCE.contains(".with_icon_as_template(false)"),
-        "the macOS tray icon must preserve its fixed white rendering"
-    );
-    assert!(
-        TRAY_SOURCE.contains("macos_white_mascot_rgba(&mut rgba, frame.width, frame.height);"),
-        "the macOS tray icon must render only internal dark details"
-    );
-}
-
 fn icns_without_chunk(bytes: &[u8], removed_kind: &[u8; 4]) -> Vec<u8> {
     let mut rebuilt = bytes[..8].to_vec();
     let mut offset = 8;

--- a/tests/desktop_assets.rs
+++ b/tests/desktop_assets.rs
@@ -412,16 +412,16 @@ fn macos_icon_contains_all_canonical_png_representations() {
 }
 
 #[test]
-fn macos_tray_icon_uses_white_and_gray_rendering() {
+fn macos_tray_icon_uses_white_mascot_with_internal_lines() {
     const TRAY_SOURCE: &str = include_str!("../src/tray/desktop.rs");
 
     assert!(
         TRAY_SOURCE.contains(".with_icon_as_template(false)"),
-        "the macOS tray icon must preserve white and gray tones"
+        "the macOS tray icon must preserve its fixed white rendering"
     );
     assert!(
-        TRAY_SOURCE.contains("macos_monochrome_rgba(&mut rgba);"),
-        "the macOS tray icon must convert the full mascot to monochrome tones"
+        TRAY_SOURCE.contains("macos_white_mascot_rgba(&mut rgba, frame.width, frame.height);"),
+        "the macOS tray icon must render only internal dark details"
     );
 }
 

--- a/tests/desktop_assets.rs
+++ b/tests/desktop_assets.rs
@@ -411,6 +411,16 @@ fn macos_icon_contains_all_canonical_png_representations() {
     validate_macos_icon(MACOS_ICNS).unwrap_or_else(|error| panic!("{error}"));
 }
 
+#[test]
+fn macos_tray_icon_is_configured_as_a_template() {
+    const TRAY_SOURCE: &str = include_str!("../src/tray/desktop.rs");
+
+    assert!(
+        TRAY_SOURCE.contains(".with_icon_as_template(true)"),
+        "the macOS tray icon must use template rendering so the system supplies monochrome colors"
+    );
+}
+
 fn icns_without_chunk(bytes: &[u8], removed_kind: &[u8; 4]) -> Vec<u8> {
     let mut rebuilt = bytes[..8].to_vec();
     let mut offset = 8;


### PR DESCRIPTION
## Summary

- Render the complete Wakezilla mascot in white in the macOS tray icon.
- Preserve only dark details that are inside the mascot; the exterior outline remains white.
- Disable macOS template tinting so the intended white-and-black rendering is retained.
- Keep Linux and Windows tray rendering unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p wakezilla --locked --features desktop-tray --test desktop_assets`
- `cargo test -p wakezilla --locked --features desktop-tray --lib tray::desktop::tests`
- `cargo check -p wakezilla --locked --features desktop-tray --bin wakezilla-tray`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the macOS tray icon’s appearance so it consistently renders as a white mascot while preserving only the intended internal dark details.
  * Disabled automatic icon template rendering to prevent unintended color changes.

* **Tests**
  * Added a macOS-only unit test (enabled under the desktop tray feature) to verify the tray icon rendering configuration and mascot recoloring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->